### PR TITLE
Reintroduce subscripting ifNull/ifNotFound methods (with deprecation warnings)

### DIFF
--- a/Sources/JSONSubscripting.swift
+++ b/Sources/JSONSubscripting.swift
@@ -539,3 +539,105 @@ extension JSON {
     }
     
 }
+
+// Deprecated methods.
+
+extension JSON {
+
+    @available(*, deprecated, message="Use decode(_:alongPath:type:) with options [.MissingKeyBecomesNil]")
+    public func decode<Decoded: JSONDecodable>(path: JSONPathType..., ifNotFound: Swift.Bool, type: Decoded.Type = Decoded.self) throws -> Decoded? {
+        let options: SubscriptingOptions = ifNotFound ? [.MissingKeyBecomesNil] : []
+        return try mapOptionalAtPath(path, alongPath: options, transform: Decoded.init)
+    }
+
+    @available(*, deprecated, message="Use decode(_:alongPath:type:) with options [.NullBecomesNil]")
+    public func decode<Decoded: JSONDecodable>(path: JSONPathType..., ifNull: Swift.Bool, type: Decoded.Type = Decoded.self) throws -> Decoded? {
+        let options: SubscriptingOptions = ifNull ? [.NullBecomesNil] : []
+        return try mapOptionalAtPath(path, alongPath: options, transform: Decoded.init)
+    }
+
+    @available(*, deprecated, message="Use double(_:alongPath:) with options [.MissingKeyBecomesNil]")
+    public func double(path: JSONPathType..., ifNotFound: Swift.Bool) throws -> Swift.Double? {
+        let options: SubscriptingOptions = ifNotFound ? [.MissingKeyBecomesNil] : []
+        return try mapOptionalAtPath(path, alongPath: options, transform: Swift.Double.init)
+    }
+
+    @available(*, deprecated, message="Use double(_:alongPath:) with options [.NullBecomesNil]")
+    public func double(path: JSONPathType..., ifNull: Swift.Bool) throws -> Swift.Double? {
+        let options: SubscriptingOptions = ifNull ? [.NullBecomesNil] : []
+        return try mapOptionalAtPath(path, alongPath: options, transform: Swift.Double.init)
+    }
+
+    @available(*, deprecated, message="Use int(_:alongPath:) with options [.MissingKeyBecomesNil]")
+    public func int(path: JSONPathType..., ifNotFound: Swift.Bool) throws -> Swift.Int? {
+        let options: SubscriptingOptions = ifNotFound ? [.MissingKeyBecomesNil] : []
+        return try mapOptionalAtPath(path, alongPath: options, transform: Swift.Int.init)
+    }
+
+    @available(*, deprecated, message="Use int(_:alongPath:) with options [.NullBecomesNil]")
+    public func int(path: JSONPathType..., ifNull: Swift.Bool) throws -> Swift.Int? {
+        let options: SubscriptingOptions = ifNull ? [.NullBecomesNil] : []
+        return try mapOptionalAtPath(path, alongPath: options, transform: Swift.Int.init)
+    }
+
+    @available(*, deprecated, message="Use string(_:alongPath:) with options [.MissingKeyBecomesNil]")
+    public func string(path: JSONPathType..., ifNotFound: Swift.Bool) throws -> Swift.String? {
+        let options: SubscriptingOptions = ifNotFound ? [.MissingKeyBecomesNil] : []
+        return try mapOptionalAtPath(path, alongPath: options, transform: Swift.String.init)
+    }
+
+    @available(*, deprecated, message="Use string(_:alongPath:) with options [.NullBecomesNil]")
+    public func string(path: JSONPathType..., ifNull: Swift.Bool) throws -> Swift.String? {
+        let options: SubscriptingOptions = ifNull ? [.NullBecomesNil] : []
+        return try mapOptionalAtPath(path, alongPath: options, transform: Swift.String.init)
+    }
+
+    @available(*, deprecated, message="Use bool(_:alongPath:) with options [.MissingKeyBecomesNil]")
+    public func bool(path: JSONPathType..., ifNotFound: Swift.Bool) throws -> Swift.Bool? {
+        let options: SubscriptingOptions = ifNotFound ? [.MissingKeyBecomesNil] : []
+        return try mapOptionalAtPath(path, alongPath: options, transform: Swift.Bool.init)
+    }
+
+    @available(*, deprecated, message="Use bool(_:alongPath:) with options [.NullBecomesNil]")
+    public func bool(path: JSONPathType..., ifNull: Swift.Bool) throws -> Swift.Bool? {
+        let options: SubscriptingOptions = ifNull ? [.NullBecomesNil] : []
+        return try mapOptionalAtPath(path, alongPath: options, transform: Swift.Bool.init)
+    }
+
+    @available(*, deprecated, message="Use array(_:alongPath:) with options [.MissingKeyBecomesNil]")
+    public func array(path: JSONPathType..., ifNotFound: Swift.Bool) throws -> [JSON]? {
+        let options: SubscriptingOptions = ifNotFound ? [.MissingKeyBecomesNil] : []
+        return try mapOptionalAtPath(path, alongPath: options, transform: JSON.getArray)
+    }
+
+    @available(*, deprecated, message="Use array(_:alongPath:) with options [.NullBecomesNil]")
+    public func array(path: JSONPathType..., ifNull: Swift.Bool) throws -> [JSON]? {
+        let options: SubscriptingOptions = ifNull ? [.NullBecomesNil] : []
+        return try mapOptionalAtPath(path, alongPath: options, transform: JSON.getArray)
+    }
+
+    @available(*, deprecated, message="Use arrayOf(_:alongPath:) with options [.MissingKeyBecomesNil]")
+    public func arrayOf<Decoded: JSONDecodable>(path: JSONPathType..., ifNotFound: Swift.Bool) throws -> [Decoded]? {
+        let options: SubscriptingOptions = ifNotFound ? [.MissingKeyBecomesNil] : []
+        return try mapOptionalAtPath(path, alongPath: options, transform: JSON.getArrayOf)
+    }
+
+    @available(*, deprecated, message="Use arrayOf(_:alongPath:) with options [.NullBecomesNil]")
+    public func arrayOf<Decoded: JSONDecodable>(path: JSONPathType..., ifNull: Swift.Bool) throws -> [Decoded]? {
+        let options: SubscriptingOptions = ifNull ? [.NullBecomesNil] : []
+        return try mapOptionalAtPath(path, alongPath: options, transform: JSON.getArrayOf)
+    }
+
+    @available(*, deprecated, message="Use dictionary(_:alongPath:) with options [.MissingKeyBecomesNil]")
+    public func dictionary(path: JSONPathType..., ifNotFound: Swift.Bool) throws -> [Swift.String: JSON]? {
+        let options: SubscriptingOptions = ifNotFound ? [.MissingKeyBecomesNil] : []
+        return try mapOptionalAtPath(path, alongPath: options, transform: JSON.getDictionary)
+    }
+
+    @available(*, deprecated, message="Use dictionary(_:alongPath:) with options [.NullBecomesNil]")
+    public func dictionary(path: JSONPathType..., ifNull: Swift.Bool) throws -> [Swift.String: JSON]? {
+        let options: SubscriptingOptions = ifNull ? [.NullBecomesNil] : []
+        return try mapOptionalAtPath(path, alongPath: options, transform: JSON.getDictionary)
+    }
+
+}

--- a/Sources/JSONSubscripting.swift
+++ b/Sources/JSONSubscripting.swift
@@ -544,97 +544,97 @@ extension JSON {
 
 extension JSON {
 
-    @available(*, deprecated, message="Use decode(_:alongPath:type:) with options [.MissingKeyBecomesNil]")
+    @available(*, deprecated, message="Use 'decode(_:alongPath:type:)' with options '[.MissingKeyBecomesNil]'")
     public func decode<Decoded: JSONDecodable>(path: JSONPathType..., ifNotFound: Swift.Bool, type: Decoded.Type = Decoded.self) throws -> Decoded? {
         let options: SubscriptingOptions = ifNotFound ? [.MissingKeyBecomesNil] : []
         return try mapOptionalAtPath(path, alongPath: options, transform: Decoded.init)
     }
 
-    @available(*, deprecated, message="Use decode(_:alongPath:type:) with options [.NullBecomesNil]")
+    @available(*, deprecated, message="Use 'decode(_:alongPath:type:)' with options '[.NullBecomesNil]'")
     public func decode<Decoded: JSONDecodable>(path: JSONPathType..., ifNull: Swift.Bool, type: Decoded.Type = Decoded.self) throws -> Decoded? {
         let options: SubscriptingOptions = ifNull ? [.NullBecomesNil] : []
         return try mapOptionalAtPath(path, alongPath: options, transform: Decoded.init)
     }
 
-    @available(*, deprecated, message="Use double(_:alongPath:) with options [.MissingKeyBecomesNil]")
+    @available(*, deprecated, message="Use 'double(_:alongPath:)' with options '[.MissingKeyBecomesNil]'")
     public func double(path: JSONPathType..., ifNotFound: Swift.Bool) throws -> Swift.Double? {
         let options: SubscriptingOptions = ifNotFound ? [.MissingKeyBecomesNil] : []
         return try mapOptionalAtPath(path, alongPath: options, transform: Swift.Double.init)
     }
 
-    @available(*, deprecated, message="Use double(_:alongPath:) with options [.NullBecomesNil]")
+    @available(*, deprecated, message="Use 'double(_:alongPath:)' with options '[.NullBecomesNil]'")
     public func double(path: JSONPathType..., ifNull: Swift.Bool) throws -> Swift.Double? {
         let options: SubscriptingOptions = ifNull ? [.NullBecomesNil] : []
         return try mapOptionalAtPath(path, alongPath: options, transform: Swift.Double.init)
     }
 
-    @available(*, deprecated, message="Use int(_:alongPath:) with options [.MissingKeyBecomesNil]")
+    @available(*, deprecated, message="Use 'int(_:alongPath:)' with options '[.MissingKeyBecomesNil]'")
     public func int(path: JSONPathType..., ifNotFound: Swift.Bool) throws -> Swift.Int? {
         let options: SubscriptingOptions = ifNotFound ? [.MissingKeyBecomesNil] : []
         return try mapOptionalAtPath(path, alongPath: options, transform: Swift.Int.init)
     }
 
-    @available(*, deprecated, message="Use int(_:alongPath:) with options [.NullBecomesNil]")
+    @available(*, deprecated, message="Use 'int(_:alongPath:)' with options '[.NullBecomesNil]'")
     public func int(path: JSONPathType..., ifNull: Swift.Bool) throws -> Swift.Int? {
         let options: SubscriptingOptions = ifNull ? [.NullBecomesNil] : []
         return try mapOptionalAtPath(path, alongPath: options, transform: Swift.Int.init)
     }
 
-    @available(*, deprecated, message="Use string(_:alongPath:) with options [.MissingKeyBecomesNil]")
+    @available(*, deprecated, message="Use 'string(_:alongPath:)' with options '[.MissingKeyBecomesNil]'")
     public func string(path: JSONPathType..., ifNotFound: Swift.Bool) throws -> Swift.String? {
         let options: SubscriptingOptions = ifNotFound ? [.MissingKeyBecomesNil] : []
         return try mapOptionalAtPath(path, alongPath: options, transform: Swift.String.init)
     }
 
-    @available(*, deprecated, message="Use string(_:alongPath:) with options [.NullBecomesNil]")
+    @available(*, deprecated, message="Use 'string(_:alongPath:)' with options '[.NullBecomesNil]'")
     public func string(path: JSONPathType..., ifNull: Swift.Bool) throws -> Swift.String? {
         let options: SubscriptingOptions = ifNull ? [.NullBecomesNil] : []
         return try mapOptionalAtPath(path, alongPath: options, transform: Swift.String.init)
     }
 
-    @available(*, deprecated, message="Use bool(_:alongPath:) with options [.MissingKeyBecomesNil]")
+    @available(*, deprecated, message="Use 'bool(_:alongPath:)' with options '[.MissingKeyBecomesNil]'")
     public func bool(path: JSONPathType..., ifNotFound: Swift.Bool) throws -> Swift.Bool? {
         let options: SubscriptingOptions = ifNotFound ? [.MissingKeyBecomesNil] : []
         return try mapOptionalAtPath(path, alongPath: options, transform: Swift.Bool.init)
     }
 
-    @available(*, deprecated, message="Use bool(_:alongPath:) with options [.NullBecomesNil]")
+    @available(*, deprecated, message="Use 'bool(_:alongPath:)' with options '[.NullBecomesNil]'")
     public func bool(path: JSONPathType..., ifNull: Swift.Bool) throws -> Swift.Bool? {
         let options: SubscriptingOptions = ifNull ? [.NullBecomesNil] : []
         return try mapOptionalAtPath(path, alongPath: options, transform: Swift.Bool.init)
     }
 
-    @available(*, deprecated, message="Use array(_:alongPath:) with options [.MissingKeyBecomesNil]")
+    @available(*, deprecated, message="Use 'array(_:alongPath:)' with options '[.MissingKeyBecomesNil]'")
     public func array(path: JSONPathType..., ifNotFound: Swift.Bool) throws -> [JSON]? {
         let options: SubscriptingOptions = ifNotFound ? [.MissingKeyBecomesNil] : []
         return try mapOptionalAtPath(path, alongPath: options, transform: JSON.getArray)
     }
 
-    @available(*, deprecated, message="Use array(_:alongPath:) with options [.NullBecomesNil]")
+    @available(*, deprecated, message="Use 'array(_:alongPath:)' with options '[.NullBecomesNil]'")
     public func array(path: JSONPathType..., ifNull: Swift.Bool) throws -> [JSON]? {
         let options: SubscriptingOptions = ifNull ? [.NullBecomesNil] : []
         return try mapOptionalAtPath(path, alongPath: options, transform: JSON.getArray)
     }
 
-    @available(*, deprecated, message="Use arrayOf(_:alongPath:) with options [.MissingKeyBecomesNil]")
+    @available(*, deprecated, message="Use 'arrayOf(_:alongPath:)' with options '[.MissingKeyBecomesNil]'")
     public func arrayOf<Decoded: JSONDecodable>(path: JSONPathType..., ifNotFound: Swift.Bool) throws -> [Decoded]? {
         let options: SubscriptingOptions = ifNotFound ? [.MissingKeyBecomesNil] : []
         return try mapOptionalAtPath(path, alongPath: options, transform: JSON.getArrayOf)
     }
 
-    @available(*, deprecated, message="Use arrayOf(_:alongPath:) with options [.NullBecomesNil]")
+    @available(*, deprecated, message="Use 'arrayOf(_:alongPath:)' with options '[.NullBecomesNil]'")
     public func arrayOf<Decoded: JSONDecodable>(path: JSONPathType..., ifNull: Swift.Bool) throws -> [Decoded]? {
         let options: SubscriptingOptions = ifNull ? [.NullBecomesNil] : []
         return try mapOptionalAtPath(path, alongPath: options, transform: JSON.getArrayOf)
     }
 
-    @available(*, deprecated, message="Use dictionary(_:alongPath:) with options [.MissingKeyBecomesNil]")
+    @available(*, deprecated, message="Use 'dictionary(_:alongPath:)' with options '[.MissingKeyBecomesNil]'")
     public func dictionary(path: JSONPathType..., ifNotFound: Swift.Bool) throws -> [Swift.String: JSON]? {
         let options: SubscriptingOptions = ifNotFound ? [.MissingKeyBecomesNil] : []
         return try mapOptionalAtPath(path, alongPath: options, transform: JSON.getDictionary)
     }
 
-    @available(*, deprecated, message="Use dictionary(_:alongPath:) with options [.NullBecomesNil]")
+    @available(*, deprecated, message="Use 'dictionary(_:alongPath:)' with options '[.NullBecomesNil]'")
     public func dictionary(path: JSONPathType..., ifNull: Swift.Bool) throws -> [Swift.String: JSON]? {
         let options: SubscriptingOptions = ifNull ? [.NullBecomesNil] : []
         return try mapOptionalAtPath(path, alongPath: options, transform: JSON.getDictionary)

--- a/Sources/JSONSubscripting.swift
+++ b/Sources/JSONSubscripting.swift
@@ -540,7 +540,7 @@ extension JSON {
     
 }
 
-// Deprecated methods.
+// MARK: - Deprecated methods
 
 extension JSON {
 

--- a/Tests/JSONDecodableTests.swift
+++ b/Tests/JSONDecodableTests.swift
@@ -194,6 +194,9 @@ class JSONDecodableTests: XCTestCase {
         do {
             let value: Int? = try JSONDictionary.int("key", alongPath: .NullBecomesNil)
             XCTAssertEqual(value, nil)
+
+            let deprecatedValue: Int? = try JSONDictionary.int("key", ifNull: true)
+            XCTAssertEqual(deprecatedValue, nil)
         } catch {
             XCTFail("Should have retrieved nil for key `key` in `JSONDictionary` when specifying `ifNull` to be `true`.")
         }

--- a/Tests/JSONDecodableTests.swift
+++ b/Tests/JSONDecodableTests.swift
@@ -194,9 +194,6 @@ class JSONDecodableTests: XCTestCase {
         do {
             let value: Int? = try JSONDictionary.int("key", alongPath: .NullBecomesNil)
             XCTAssertEqual(value, nil)
-
-            let deprecatedValue: Int? = try JSONDictionary.int("key", ifNull: true)
-            XCTAssertEqual(deprecatedValue, nil)
         } catch {
             XCTFail("Should have retrieved nil for key `key` in `JSONDictionary` when specifying `ifNull` to be `true`.")
         }

--- a/Tests/JSONSubscriptingTests.swift
+++ b/Tests/JSONSubscriptingTests.swift
@@ -343,12 +343,18 @@ class JSONSubscriptingTests: XCTestCase {
         let earlyNull = [ "foo": nil ] as JSON
         let string = try! earlyNull.string("foo", "bar", "baz", alongPath: .NullBecomesNil)
         XCTAssertNil(string)
+
+        let deprecatedString = try! earlyNull.string("foo", "bar", "baz", ifNull: true)
+        XCTAssertNil(deprecatedString)
     }
     
     func testThatOptionalSubscriptingKeyNotFoundSucceeds() {
         let keyNotFound = [ "foo": 2 ] as JSON
         let string = try! keyNotFound.string("bar", alongPath: .MissingKeyBecomesNil)
         XCTAssertNil(string)
+
+        let deprecatedString = try! keyNotFound.string("bar", ifNotFound: true)
+        XCTAssertNil(deprecatedString)
     }
     
 }
@@ -411,4 +417,23 @@ private func testUsage() {
     _ = try? j.int(stringConst, 2, alongPath: .MissingKeyBecomesNil)
     _ = try? j.int(stringConst, 3, alongPath: .NullBecomesNil)
     _ = try? j.int(stringConst, 4, or: 42)
+}
+
+// Just for deprecated syntax validation, not for execution or being counted for coverage.
+private func testDeprecatedUsage() {
+    let j = JSON.Null
+
+    _ = try? j.int(ifNotFound: true)
+    _ = try? j.int(ifNull: true)
+
+    _ = try? j.int("key", ifNotFound: true)
+    _ = try? j.int("key", ifNull: true)
+
+    _ = try? j.int(2, ifNotFound: true)
+    _ = try? j.int(3, ifNull: true)
+
+    let stringConst = "key"
+
+    _ = try? j.int(stringConst, 2, ifNotFound: true)
+    _ = try? j.int(stringConst, 3, ifNull: true)
 }

--- a/Tests/JSONSubscriptingTests.swift
+++ b/Tests/JSONSubscriptingTests.swift
@@ -343,18 +343,12 @@ class JSONSubscriptingTests: XCTestCase {
         let earlyNull = [ "foo": nil ] as JSON
         let string = try! earlyNull.string("foo", "bar", "baz", alongPath: .NullBecomesNil)
         XCTAssertNil(string)
-
-        let deprecatedString = try! earlyNull.string("foo", "bar", "baz", ifNull: true)
-        XCTAssertNil(deprecatedString)
     }
     
     func testThatOptionalSubscriptingKeyNotFoundSucceeds() {
         let keyNotFound = [ "foo": 2 ] as JSON
         let string = try! keyNotFound.string("bar", alongPath: .MissingKeyBecomesNil)
         XCTAssertNil(string)
-
-        let deprecatedString = try! keyNotFound.string("bar", ifNotFound: true)
-        XCTAssertNil(deprecatedString)
     }
     
 }
@@ -417,23 +411,4 @@ private func testUsage() {
     _ = try? j.int(stringConst, 2, alongPath: .MissingKeyBecomesNil)
     _ = try? j.int(stringConst, 3, alongPath: .NullBecomesNil)
     _ = try? j.int(stringConst, 4, or: 42)
-}
-
-// Just for deprecated syntax validation, not for execution or being counted for coverage.
-private func testDeprecatedUsage() {
-    let j = JSON.Null
-
-    _ = try? j.int(ifNotFound: true)
-    _ = try? j.int(ifNull: true)
-
-    _ = try? j.int("key", ifNotFound: true)
-    _ = try? j.int("key", ifNull: true)
-
-    _ = try? j.int(2, ifNotFound: true)
-    _ = try? j.int(3, ifNull: true)
-
-    let stringConst = "key"
-
-    _ = try? j.int(stringConst, 2, ifNotFound: true)
-    _ = try? j.int(stringConst, 3, ifNull: true)
 }


### PR DESCRIPTION
This PR reintroduces the `... ifNotFound: ...` and `... ifNull: ...` subscripting methods to keep backwards compatibility. They are flagged as deprecated, with the message pointing to the new `... alongPath: ...` methods.

This branch is currently pointed at the #148 branch. If that branch is merged first we can trivially rebase this onto master.

Downsides to this PR:
* Swift doesn't yet support library version numbers - `@available` is tied to OS version releases, so we use a flat `@available(*, deprecated, ...)`. [There are plans](https://github.com/apple/swift/blob/master/docs/LibraryEvolution.rst) for library versioning, but it's not around yet.
* Our unit tests now have about a dozen warnings from calling deprecated methods. Not sure how valuable it is to keep those around now that we see that they work.