### PR TITLE
Catch numeric overflow errors and parse the numbers as strings instead.

### DIFF
--- a/Sources/JSONDecodable.swift
+++ b/Sources/JSONDecodable.swift
@@ -48,7 +48,7 @@ extension Int: JSONDecodable {
     ///           passed to this initializer.
     public init(json: JSON) throws {
         switch json {
-        case let .Double(double):
+        case let .Double(double) where double <= Double(Swift.Int.max):
             self = Swift.Int(double)
         case let .Int(int):
             self = int

--- a/Sources/JSONParser.swift
+++ b/Sources/JSONParser.swift
@@ -570,12 +570,13 @@ public struct JSONParser {
                 parser.parseExponentDigits { stringDecodingBuffer.append($0) }
 
             case .Done:
+                stringDecodingBuffer.append(0)
                 guard let string = (stringDecodingBuffer.withUnsafeBufferPointer {
                     String.fromCString(UnsafePointer($0.baseAddress))
-                    }) else {
-                        // Should never fail - any problems with the number string should
-                        // result in thrown errors above
-                        fatalError("Internal error: Invalid numeric string")
+                }) else {
+                    // Should never fail - any problems with the number string should
+                    // result in thrown errors above
+                    fatalError("Internal error: Invalid numeric string")
                 }
 
                 loc = parser.loc

--- a/Sources/JSONParser.swift
+++ b/Sources/JSONParser.swift
@@ -443,7 +443,9 @@ public struct JSONParser {
         var parser = parser
         var value = 0
 
-        while true {
+        // This would be more natural as `while true { ... }` with a meaningful .Done case,
+        // but that causes compile time explosion in Swift 2.2. :-|
+        while parser.state != .Done {
             switch parser.state {
             case .LeadingMinus:
                 sign = .Negative
@@ -474,14 +476,16 @@ public struct JSONParser {
                 assertionFailure("Invalid internal state while parsing number")
 
             case .Done:
-                guard case let (signedValue, false) = Int.multiplyWithOverflow(sign.rawValue, value) else {
-                    throw InternalError.NumberOverflow(offset: parser.start)
-                }
-
-                loc = parser.loc
-                return .Int(signedValue)
+                fatalError("impossible condition")
             }
         }
+
+        guard case let (signedValue, false) = Int.multiplyWithOverflow(sign.rawValue, value) else {
+            throw InternalError.NumberOverflow(offset: parser.start)
+        }
+
+        loc = parser.loc
+        return .Int(signedValue)
     }
 
     private mutating func decodeFloatingPointValue(parser: NumberParser, sign: Sign, value: Double) throws -> JSON {
@@ -491,7 +495,9 @@ public struct JSONParser {
         var exponent = Double(0)
         var position = 0.1
 
-        while true {
+        // This would be more natural as `while true { ... }` with a meaningful .Done case,
+        // but that causes compile time explosion in Swift 2.2. :-|
+        while parser.state != .Done {
             switch parser.state {
             case .LeadingMinus, .LeadingZero, .PreDecimalDigits:
                 assertionFailure("Invalid internal state while parsing number")
@@ -517,10 +523,12 @@ public struct JSONParser {
                 }
 
             case .Done:
-                loc = parser.loc
-                return .Double(Double(sign.rawValue) * value * pow(10, Double(exponentSign.rawValue) * exponent))
+                fatalError("impossible condition")
             }
         }
+
+        loc = parser.loc
+        return .Double(Double(sign.rawValue) * value * pow(10, Double(exponentSign.rawValue) * exponent))
     }
 
     private mutating func decodeNumberAsString(start: Int) throws -> JSON {

--- a/Sources/JSONParsing.swift
+++ b/Sources/JSONParsing.swift
@@ -59,7 +59,6 @@ extension NSJSONSerialization: JSONParserType {
         case let n as NSNumber:
             let numberType = CFNumberGetType(n)
             switch numberType {
-            case _ where CFGetTypeID(n) == CFBooleanGetTypeID(): fallthrough
             case .CharType:
                 return .Bool(n.boolValue)
 

--- a/Sources/JSONParsing.swift
+++ b/Sources/JSONParsing.swift
@@ -57,39 +57,41 @@ extension NSJSONSerialization: JSONParserType {
     private static func makeJSON(object: AnyObject) -> JSON {
         switch object {
         case let n as NSNumber:
-            let numberType = CFNumberGetType(n)
-            let isBoolean = numberType == .CharType || CFGetTypeID(n) == CFBooleanGetTypeID()
-            if isBoolean {
+            if CFGetTypeID(n) == CFBooleanGetTypeID() {
                 return .Bool(n.boolValue)
             }
 
-#if /* compiling for a target with 32-bit Int */ arch(arm) || arch(i386)
-            let overflowsInt = (numberType == .SInt64Type
-                || numberType == .LongLongType)
-            if overflowsInt {
-                // Why double, when the Freddy parser would bump to String?
-                //
-                // Returning Double avoids making the type depend on whether you're running
-                // 32-bit or 64-bit code when using the NSJSONSerialization parser.
-                // NSJSONSerialization appears to bump numbers larger than Int.max to Double on
-                // 64-bit platforms but use .SInt64Type on 32-bit platforms.
-                // If we returned a String here, you'd get a String value on 32-bit,
-                // but a Double value on 64-bit. Instead, we return Double.
-                //
-                // This means that, if you switch parsers,
-                // you'll have to switch from .double to .string for pulling out
-                // overflowing values, but if you stick with a single parser,
-                // you at least won't have architecture-dependent lookups!
+            let numberType = CFNumberGetType(n)
+            switch numberType {
+            case .CharType:
+                return .Bool(n.boolValue)
+
+            case .ShortType, .IntType, .LongType, .CFIndexType, .NSIntegerType, .SInt8Type, .SInt16Type, .SInt32Type:
+                return .Int(n.integerValue)
+
+            case .SInt64Type, .LongLongType /* overflows 32-bit Int */:
+                #if /* 32-bit arch */ arch(arm) || arch(i386)
+                    // Why double, when the Freddy parser would bump to String?
+                    //
+                    // Returning Double avoids making the type depend on whether you're running
+                    // 32-bit or 64-bit code when using the NSJSONSerialization parser.
+                    // NSJSONSerialization appears to bump numbers larger than Int.max to Double on
+                    // 64-bit platforms but use .SInt64Type on 32-bit platforms.
+                    // If we returned a String here, you'd get a String value on 32-bit,
+                    // but a Double value on 64-bit. Instead, we return Double.
+                    //
+                    // This means that, if you switch parsers,
+                    // you'll have to switch from .double to .string for pulling out
+                    // overflowing values, but if you stick with a single parser,
+                    // you at least won't have architecture-dependent lookups!
+                    return .Double(n.doubleValue)
+                #else
+                    return .Int(n.integerValue)
+                #endif
+
+            case .Float32Type, .Float64Type, .FloatType, .DoubleType, .CGFloatType:
                 return .Double(n.doubleValue)
             }
-#endif
-
-            let isInt = !CFNumberIsFloatType(n)
-            if isInt {
-                return .Int(n.integerValue)
-            }
-
-            return .Double(n.doubleValue)
 
         case let arr as [AnyObject]:
             return makeJSONArray(arr)

--- a/Sources/JSONParsing.swift
+++ b/Sources/JSONParsing.swift
@@ -57,12 +57,9 @@ extension NSJSONSerialization: JSONParserType {
     private static func makeJSON(object: AnyObject) -> JSON {
         switch object {
         case let n as NSNumber:
-            if CFGetTypeID(n) == CFBooleanGetTypeID() {
-                return .Bool(n.boolValue)
-            }
-
             let numberType = CFNumberGetType(n)
             switch numberType {
+            case _ where CFGetTypeID(n) == CFBooleanGetTypeID(): fallthrough
             case .CharType:
                 return .Bool(n.boolValue)
 

--- a/Sources/JSONParsing.swift
+++ b/Sources/JSONParsing.swift
@@ -64,12 +64,14 @@ extension NSJSONSerialization: JSONParserType {
             }
 
 #if /* compiling for a target with 32-bit Int */ arch(arm) || arch(i386)
-            let isInt = (!CFNumberIsFloatType(n)
-                && numberType != .SInt64Type
-                && numberType != .LongLongType)
-#else
-            let isInt = !CFNumberIsFloatType(n)
+            let overflowsInt = (numberType == .SInt64Type
+                || numberType == .LongLongType)
+            if overflowsInt {
+                return .String(n.description)
+            }
 #endif
+
+            let isInt = !CFNumberIsFloatType(n)
             if isInt {
                 return .Int(n.integerValue)
             }

--- a/Tests/JSONParserTests.swift
+++ b/Tests/JSONParserTests.swift
@@ -250,13 +250,8 @@ class JSONParserTests: XCTestCase {
         // Under both 32- and 64-bit, we get:
         //     fatal error: floating point value can not be converted to Int because it is greater than Int.max
         //XCTAssertEqual(try? json.int("exceedsIntMax"), nil, "as int")
-        #if /* 32-bit architecture */ arch(i386) || arch(arm)
-            XCTAssertEqual(try? json.double("exceedsIntMax"), nil, "as double")
-            XCTAssertEqual(try? json.string("exceedsIntMax"), anyValueExceedingIntMax.description, "as string")
-        #else
-            XCTAssertEqual(try? json.double("exceedsIntMax"), Double(anyValueExceedingIntMax), "as double")
-            XCTAssertEqual(try? json.string("exceedsIntMax"), nil, "as string")
-        #endif
+        XCTAssertEqual(try? json.double("exceedsIntMax"), Double(anyValueExceedingIntMax), "as double")
+        XCTAssertEqual(try? json.string("exceedsIntMax"), nil, "as string")
     }
 
     // This test should also be run on the iPhone 5 simulator to check 32-bit support.

--- a/Tests/JSONParserTests.swift
+++ b/Tests/JSONParserTests.swift
@@ -247,9 +247,7 @@ class JSONParserTests: XCTestCase {
             return
         }
 
-        // Under both 32- and 64-bit, we get:
-        //     fatal error: floating point value can not be converted to Int because it is greater than Int.max
-        //XCTAssertEqual(try? json.int("exceedsIntMax"), nil, "as int")
+        XCTAssertEqual(try? json.int("exceedsIntMax"), nil, "as int")
         XCTAssertEqual(try? json.double("exceedsIntMax"), Double(anyValueExceedingIntMax), "as double")
         XCTAssertEqual(try? json.string("exceedsIntMax"), nil, "as string")
     }
@@ -269,6 +267,22 @@ class JSONParserTests: XCTestCase {
         XCTAssertEqual(try? json.int("exceedsIntMax"), nil, "as int")
         XCTAssertEqual(try? json.double("exceedsIntMax"), nil, "as double")
         XCTAssertEqual(try? json.string("exceedsIntMax"), anyValueExceedingIntMax.description, "as string")
+    }
+
+    // This was tripping a fatalError with the Freddy parser for 64-bit at one point:
+    //     fatal error: floating point value can not be converted to Int because it is greater than Int.max
+    // because we assumed the double would be in range of Int.
+    func testReturnsNilWhenDoubleValueExceedingIntMaxIsAccessedAsInt() {
+        let anyFloatingPointValueExceedingIntMax = Double(UInt(Int.max) + 1)
+        let jsonString = "{\"exceedsIntMax\": \(anyFloatingPointValueExceedingIntMax)}"
+
+        let data = jsonString.dataUsingEncoding(NSUTF8StringEncoding)!
+        guard let json = try? JSON(data: data) else {
+            XCTFail("Failed to even parse JSON: \(jsonString)")
+            return
+        }
+
+        XCTAssertEqual(try? json.int("exceedsIntMax"), nil, "as int")
     }
 
     func testThatParserUnderstandsEmptyArrays() {

--- a/Tests/JSONParserTests.swift
+++ b/Tests/JSONParserTests.swift
@@ -224,11 +224,41 @@ class JSONParserTests: XCTestCase {
                     let json = try JSONFromString(string)
 
                     // numbers overflow, but we should be able to get them out as strings
-                    XCTAssertEqual(try json.string(), string)
+                    XCTAssertEqual(try? json.string(), string)
                 } catch {
                     XCTFail("Unexpected error \(error)")
                 }
         }
+    }
+
+    // This test should be run on the iPhone 5 simulator to actually do its job.
+    func test32BitOverflowResultsInDoubleWithNSJSONSerializationParser() {
+        let jsonString = "{\"startDate\": 1466719200000}"
+        let expectedValue = 1466719200000.0
+
+        let data = jsonString.dataUsingEncoding(NSUTF8StringEncoding)!
+        guard let json = try? JSON(data: data, usingParser: NSJSONSerialization.self) else {
+            XCTFail("Failed to even parse JSON: \(jsonString)")
+            return
+        }
+
+        XCTAssertEqual(try? json.double("startDate"), expectedValue, "startDate as double")
+        XCTAssertEqual(try? json.string("startDate"), nil, "startDate as string")
+    }
+
+    // This test should be run on the iPhone 5 simulator to actually do its job.
+    func test32BitOverflowResultsInStringWithFreddyParser() {
+        let jsonString = "{\"startDate\": 1466719200000}"
+        let expectedValue = "1466719200000"
+
+        let data = jsonString.dataUsingEncoding(NSUTF8StringEncoding)!
+        guard let json = try? JSON(data: data) else {
+            XCTFail("Failed to even parse JSON: \(jsonString)")
+            return
+        }
+
+        XCTAssertEqual(try? json.double("startDate"), nil, "startDate as double")
+        XCTAssertEqual(try? json.string("startDate"), expectedValue, "startDate as string")
     }
 
     func testThatParserUnderstandsEmptyArrays() {

--- a/Tests/JSONParserTests.swift
+++ b/Tests/JSONParserTests.swift
@@ -37,8 +37,6 @@ private func ==(lhs: JSONParser.Error, rhs: JSONParser.Error) -> Bool {
         return lOffset == rOffset
     case let (.NumberSymbolMissingDigits(lOffset), .NumberSymbolMissingDigits(rOffset)):
         return lOffset == rOffset
-    case let (.NumberOverflow(lOffset), .NumberOverflow(rOffset)):
-        return lOffset == rOffset
     case (_, _):
         return false
     }
@@ -202,21 +200,21 @@ class JSONParserTests: XCTestCase {
     }
 
     func testParserHandlingOfNumericOverflow() {
-        for (string, expectedError) in [
+        for string in [
             // Int64.max + 1
-            ("9223372036854775808", JSONParser.Error.NumberOverflow(offset: 0)),
+            "9223372036854775808",
 
             // DBL_MAX is 1.7976931348623158e+308, so add 1 to least significant
-            ("1.7976931348623159e+308", JSONParser.Error.NumberOverflow(offset: 0)),
+            "1.7976931348623159e+308",
 
             // DBL_TRUE_MIN is 4.9406564584124654E-324, so try something smaller
-            ("4.9406564584124654E-325", JSONParser.Error.NumberOverflow(offset: 0)),
+            "4.9406564584124654E-325",
             ] {
                 do {
-                    let value = try JSONFromString(string)
-                    XCTFail("Unexpected success: \(value)")
-                } catch let error as JSONParser.Error {
-                    XCTAssert(error == expectedError, "Expected \(expectedError) but got \(error)")
+                    let json = try JSONFromString(string)
+
+                    // numbers overflow, but we should be able to get them out as strings
+                    XCTAssertEqual(try json.string(), string)
                 } catch {
                     XCTFail("Unexpected error \(error)")
                 }

--- a/Tests/JSONParserTests.swift
+++ b/Tests/JSONParserTests.swift
@@ -159,7 +159,12 @@ class JSONParserTests: XCTestCase {
             ("123", 123),
             ("  -20  ", -20),
         ] {
-            XCTAssertEqual(try! JSONFromString(string).int(), shouldBeInt)
+            do {
+                let value = try JSONFromString(string).int()
+                XCTAssertEqual(value, shouldBeInt)
+            } catch {
+                XCTFail("Unexpected error: \(error)")
+            }
         }
 
         for (string, shouldBeDouble) in [
@@ -173,7 +178,12 @@ class JSONParserTests: XCTestCase {
             ("123.45e+2", 123.45e+2),
             ("-123.45e-2", -123.45e-2),
         ] {
-            XCTAssertEqualWithAccuracy(try! JSONFromString(string).double(), shouldBeDouble, accuracy: DBL_EPSILON)
+            do {
+                let value = try JSONFromString(string).double()
+                XCTAssertEqualWithAccuracy(value, shouldBeDouble, accuracy: DBL_EPSILON)
+            } catch {
+                XCTFail("Unexpected error: \(error)")
+            }
         }
     }
 


### PR DESCRIPTION
Closes #76.

Makes no changes to the "fast path" of numbers that don't overflow. If a numeric overflow is detected (via a thrown `NumberOverflow`, which is now a private error), we go back to the beginning of the number and re-parse it for validity only, returning it as a `.String`.

The good: Returns overflows as strings (e.g., see [the unit tests](https://github.com/bignerdranch/Freddy/blob/9329ad68ccca24e473e49f7ee7487cccf8a6357a/Tests/JSONParserTests.swift#L202-L222)) without slowing down the parser.

~~The bad: We would now have two nearly identical groups of methods that parse numbers - one accumulates values and the other just looks for the end.~~

~~If we want to close #76 as part of 2.1, we could merge this and open a separate issue to clean up the internals. Not sure how to do that without sacrificing performance at the moment, but I'm sure we can come up with something.~~

Update from last couple commits - extracted number parsing out into a common struct with an internal state machine. Much less duplication between parsing numbers as numbers and parsing numbers as strings. Minimal slowdown (~1% on benchmarking branch).