### PR TITLE
Updated Podspec to include framework’s interface files

### DIFF
--- a/Freddy.podspec
+++ b/Freddy.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target    = "9.0"
 
   s.source = {:git => "https://github.com/bignerdranch/Freddy.git", :tag => "#{s.version}"}
-  s.source_files  = "Sources/**/*.swift"
+  s.source_files  = "Sources/**/*.{h, swift}"
 
   s.requires_arc = true
 

--- a/Freddy.podspec
+++ b/Freddy.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target    = "9.0"
 
   s.source = {:git => "https://github.com/bignerdranch/Freddy.git", :tag => "#{s.version}"}
-  s.source_files  = "Sources/**/*.{h, swift}"
+  s.source_files  = "Sources/**/*.{h,swift}"
 
   s.requires_arc = true
 


### PR DESCRIPTION
# Why

When including Freddy as dependency in another pod's Podspec it doesn't get properly included in the target project due to a lack of framework's interface file required by CocoaPods. Because of this, Freddy's module is not found when trying to compile the target project.

# What

To fix this issue I've updated the Podspec to also include the header file of the project as part of the pod's `source_files`. 