### PR TITLE
Add dictionaryOf method

### DIFF
--- a/Sources/JSONDecodable.swift
+++ b/Sources/JSONDecodable.swift
@@ -138,7 +138,7 @@ internal extension JSON {
     /// Attempts to decode many values from a descendant JSON array at a path
     /// into JSON.
     /// - parameter: A `JSON` to be used to create the returned `Array` of some type conforming to `JSONDecodable`.
-    /// - returns: An `Array` of decoded elements
+    /// - returns: An `Array` of `Decoded` elements.
     /// - throws: Any of the `JSON.Error` cases thrown by `decode(type:)`, as
     ///   well as any error that arises from decoding the contained values.
     /// - seealso: `JSON.decode(_:type:)`

--- a/Sources/JSONDecodable.swift
+++ b/Sources/JSONDecodable.swift
@@ -148,4 +148,24 @@ internal extension JSON {
         return try getArray(json).map(Decoded.init)
     }
     
+    /// Attempts to decode many values from a descendant JSON object at a path
+    /// into JSON.
+    /// - parameter type: If the context this method is called from does not
+    ///                   make the return type clear, pass a type implementing `JSONDecodable`
+    ///                   to disambiguate the value type to decode with.
+    /// - returns: A `Dictionary` of string keys and decoded values.
+    /// - throws: One of the `JSON.Error` cases thrown by `decode(_:type:)` or
+    ///           any error that arises from decoding the contained values.
+    /// - seealso: `JSON.decode(_:type:)`
+    static func getDictionaryOf<Decoded: JSONDecodable>(json: JSON) throws -> [Swift.String: Decoded] {
+        guard case let .Dictionary(dictionary) = json else {
+            throw Error.ValueNotConvertible(value: json, to: Swift.Dictionary<Swift.String, JSON>)
+        }
+        var decodedDictionary: [Swift.String: Decoded] = [:]
+        for (key, value) in dictionary {
+            decodedDictionary[key] = try Decoded(json: value)
+        }
+        return decodedDictionary
+    }
+    
 }

--- a/Sources/JSONDecodable.swift
+++ b/Sources/JSONDecodable.swift
@@ -150,18 +150,15 @@ internal extension JSON {
     
     /// Attempts to decode many values from a descendant JSON object at a path
     /// into JSON.
-    /// - parameter type: If the context this method is called from does not
-    ///                   make the return type clear, pass a type implementing `JSONDecodable`
-    ///                   to disambiguate the value type to decode with.
-    /// - returns: A `Dictionary` of string keys and decoded values.
+    /// - returns: A `Dictionary` of string keys and `Decoded` values.
     /// - throws: One of the `JSON.Error` cases thrown by `decode(_:type:)` or
     ///           any error that arises from decoding the contained values.
     /// - seealso: `JSON.decode(_:type:)`
     static func getDictionaryOf<Decoded: JSONDecodable>(json: JSON) throws -> [Swift.String: Decoded] {
         guard case let .Dictionary(dictionary) = json else {
-            throw Error.ValueNotConvertible(value: json, to: Swift.Dictionary<Swift.String, JSON>)
+            throw Error.ValueNotConvertible(value: json, to: Swift.Dictionary<Swift.String, Decoded>)
         }
-        var decodedDictionary: [Swift.String: Decoded] = [:]
+        var decodedDictionary = Swift.Dictionary<Swift.String, Decoded>(minimumCapacity: dictionary.count)
         for (key, value) in dictionary {
             decodedDictionary[key] = try Decoded(json: value)
         }

--- a/Sources/JSONSubscripting.swift
+++ b/Sources/JSONSubscripting.swift
@@ -381,6 +381,9 @@ extension JSON {
     /// JSON.
     /// - parameter path: 0 or more `String` or `Int` that subscript the `JSON`
     /// - parameter alongPath: Options that control what should be done with values that are `null` or keys that are missing.
+    /// - parameter type: If the context this method is called from does not
+    ///                   make the return type clear, pass a type implementing `JSONDecodable`
+    ///                   to disambiguate the value type to decode with.
     /// - returns: An `Array` of decoded elements if found, otherwise `nil`.
     /// - throws: One of the following errors contained in `JSON.Error`:
     ///   * `KeyNotFound`: A key `path` does not exist inside a descendant

--- a/Sources/JSONSubscripting.swift
+++ b/Sources/JSONSubscripting.swift
@@ -417,6 +417,9 @@ extension JSON {
     /// into JSON.
     /// - parameter path: 0 or more `String` or `Int` that subscript the `JSON`
     /// - parameter alongPath: Options that control what should be done with values that are `null` or keys that are missing.
+    /// - parameter type: If the context this method is called from does not
+    ///                   make the return type clear, pass a type implementing `JSONDecodable`
+    ///                   to disambiguate the value type to decode with.
     /// - returns: A `Dictionary` of `String` mapping to decoded elements if a
     ///            value could be found, otherwise `nil`.
     /// - throws: One of the following errors contained in `JSON.Error`:

--- a/Sources/JSONSubscripting.swift
+++ b/Sources/JSONSubscripting.swift
@@ -189,7 +189,7 @@ extension JSON {
         return try JSON.getArray(valueAtPath(path))
     }
 
-    /// Attempts to decodes many values from a desendant JSON array at a path
+    /// Attempts to decode many values from a descendant JSON array at a path
     /// into JSON.
     /// - parameter path: 0 or more `String` or `Int` that subscript the `JSON`
     /// - parameter type: If the context this method is called from does not
@@ -210,6 +210,20 @@ extension JSON {
     /// - seealso: `JSON.decode(_:type:)`
     public func dictionary(path: JSONPathType...) throws -> [Swift.String: JSON] {
         return try JSON.getDictionary(valueAtPath(path))
+    }
+    
+    /// Attempts to decode many values from a descendant JSON object at a path
+    /// into JSON.
+    /// - parameter path: 0 or more `String` or `Int` that subscript the `JSON`
+    /// - parameter type: If the context this method is called from does not
+    ///                   make the return type clear, pass a type implementing `JSONDecodable`
+    ///                   to disambiguate the value type to decode with.
+    /// - returns: A `Dictionary` of `String` keys and decoded values.
+    /// - throws: One of the `JSON.Error` cases thrown by `decode(_:type:)` or
+    ///           any error that arises from decoding the contained values.
+    /// - seealso: `JSON.decode(_:type:)`
+    public func dictionaryOf<Decoded: JSONDecodable>(path: JSONPathType..., type: Decoded.Type = Decoded.self) throws -> [Swift.String: Decoded] {
+        return try JSON.getDictionaryOf(valueAtPath(path))
     }
 
 }
@@ -398,6 +412,26 @@ extension JSON {
     public func dictionary(path: JSONPathType..., alongPath options: SubscriptingOptions) throws -> [Swift.String: JSON]? {
         return try mapOptionalAtPath(path, alongPath: options, transform: JSON.getDictionary)
     }
+    
+    /// Optionally attempts to decode many values from a descendant object at a path
+    /// into JSON.
+    /// - parameter path: 0 or more `String` or `Int` that subscript the `JSON`
+    /// - parameter alongPath: Options that control what should be done with values that are `null` or keys that are missing.
+    /// - returns: A `Dictionary` of `String` mapping to decoded elements if a
+    ///            value could be found, otherwise `nil`.
+    /// - throws: One of the following errors contained in `JSON.Error`:
+    ///   * `KeyNotFound`: A key `path` does not exist inside a descendant
+    ///     `JSON` dictionary.
+    ///   * `IndexOutOfBounds`: An index `path` is outside the bounds of a
+    ///     descendant `JSON` array.
+    ///   * `UnexpectedSubscript`: A `path` item cannot be used with the
+    ///     corresponding `JSON` value.
+    ///   * `TypeNotConvertible`: The target value's type inside of the `JSON`
+    ///     instance does not match the decoded value.
+    ///   * Any error that arises from decoding the value.
+    public func dictionaryOf<Decoded: JSONDecodable>(path: JSONPathType..., alongPath options: SubscriptingOptions, type: Decoded.Type = Decoded.self) throws -> [Swift.String: Decoded]? {
+        return try mapOptionalAtPath(path, alongPath: options, transform: JSON.getDictionaryOf)
+    }
 
 }
 
@@ -537,6 +571,26 @@ extension JSON {
     public func dictionary(path: JSONPathType..., @autoclosure or fallback: () -> [Swift.String: JSON]) throws -> [Swift.String: JSON] {
         return try mapOptionalAtPath(path, fallback: fallback, transform: JSON.getDictionary)
     }
+    
+    /// Attempts to decode many values from a descendant JSON object at a path
+    /// into the receiving structure, returning a fallback if not found.
+    /// - parameter path: 0 or more `String` or `Int` that subscript the `JSON`
+    /// - parameter fallback: Value to use when one is missing at the subscript
+    /// - returns: A `Dictionary` of `String` mapping to decoded elements.
+    /// - throws: One of the following errors contained in `JSON.Error`:
+    ///   * `KeyNotFound`: A key `path` does not exist inside a descendant
+    ///     `JSON` dictionary.
+    ///   * `IndexOutOfBounds`: An index `path` is outside the bounds of a
+    ///     descendant `JSON` array.
+    ///   * `UnexpectedSubscript`: A `path` item cannot be used with the
+    ///     corresponding `JSON` value.
+    ///   * `TypeNotConvertible`: The target value's type inside of the `JSON`
+    ///     instance does not match the decoded value.
+    ///   * Any error that arises from decoding the value.
+    public func dictionaryOf<Decoded: JSONDecodable>(path: JSONPathType..., @autoclosure or fallback: () -> [Swift.String: Decoded]) throws -> [Swift.String: Decoded] {
+        return try mapOptionalAtPath(path, fallback: fallback, transform: JSON.getDictionaryOf)
+    }
+    
     
 }
 

--- a/Tests/JSONDecodableTests.swift
+++ b/Tests/JSONDecodableTests.swift
@@ -188,6 +188,17 @@ class JSONDecodableTests: XCTestCase {
         }
     }
     
+    func testThatDictionaryOfCanReturnDictionaryOfJSONDecodable() {
+        let oneTwoThreeJSON: JSON = ["one": 1, "two": 2, "three": 3]
+        
+        do {
+            let decodedOneTwoThree = try oneTwoThreeJSON.dictionaryOf(type: Swift.Int)
+            XCTAssertEqual(decodedOneTwoThree, ["one": 1, "two": 2, "three": 3], "`decodedOneTwoThree` should be equal to `[\"one\": 1, \"two\": 2, \"three\": 3]`.")
+        } catch {
+            XCTFail("`decodedOneTwoThree` should be equal to `[\"one\": 1, \"two\": 2, \"three\": 3]`.")
+        }
+    }
+    
     func testThatNullIsDecodedToNilWhenRequestedAtTopLevel() {
         let JSONDictionary: JSON = ["key": .Null]
         


### PR DESCRIPTION
### Overview

This pull request adds a `dictionaryOf(_:type:)` function that is analogous to the existing `arrayOf(_:type:)` function.

### Example

This pull request makes the following example possible:

```swift
let residentJSON = JSON.Dictionary([
    "residentsByName": [
        "Matt": ["name": "Matt", "age": 33, "hasPet": false, "rent": .Null],
        "Drew": ["name": "Drew", "hasPet": true, "rent": 1234.5],
        "Pat": ["name": "Pat", "age": 28, "hasPet": .Null]
    ]
])

do {
    let residents = try residentJSON.dictionaryOf("residentsByName", type: Resident.self)
    if let matt = residents["Matt"] {
        print("Matt is \(matt.age) years old.")
    }
} catch {
    // handle error
}
```

### Justification

I admit that it's rare to run into JSON that would make use of the `dictionaryOf(_:type:)` function. However, I needed something similar to decode [this parameter](https://github.com/watson-developer-cloud/ios-sdk/blob/master/Source/SpeechToTextV1/Models/TranscriptionResult.swift#L34) in the [IBM Watson Developer Cloud iOS SDK](https://github.com/watson-developer-cloud/ios-sdk).

The [IBM Watson Speech to Text documentation](https://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/speech-to-text/api/v1/#recognize_audio_sessions18) provides an example JSON payload for which the `dictionaryOf(_:type:)` function would be very helpful:

```swift
{
  "keywords_result": {
     "tornadoes": [
        {
           "normalized_text": "tornadoes",
           "start_time": 1.52,
           "confidence": 1.0,
           "end_time": 2.15
        }
     ],
     "colorado": [
        {
           "normalized_text": "Colorado",
           "start_time": 4.94,
           "confidence": 0.925,
           "end_time": 5.62
        }
     ]
  }
}
```

In particular, I believe the following should be able to decode the JSON payload:

```swift
public struct TranscriptionResult: JSONDecodable {

    public let keywordResults: [String: [KeywordResult]]

    public init(json: JSON) throws {
        keywordResults = try json.dictionaryOf("keywords_result")
    }
}
```

### Implementation Notes

I tried to follow the example of the `arrayOf(_:type:)` function. I used it (and its documentation) as the starting point for `dictionaryOf(_:type:)`. Hopefully, these changes are consistent with your style as a result.

I also searched for all occurrences of `arrayOf` so I could add an analogous use of `dictionaryOf`.