### PR TITLE
- updates for Xcode 8 beta 4

### DIFF
--- a/Sources/JSON.swift
+++ b/Sources/JSON.swift
@@ -29,7 +29,7 @@ public enum JSON {
 extension JSON {
 
     /// An enum to encapsulate errors that may arise in working with `JSON`.
-    public enum Error: ErrorProtocol {
+    public enum Error: Swift.Error {
         /// The `index` is out of bounds for a JSON array
         case indexOutOfBounds(index: Swift.Int)
         

--- a/Sources/JSON.swift
+++ b/Sources/JSON.swift
@@ -29,7 +29,7 @@ public enum JSON {
 extension JSON {
 
     /// An enum to encapsulate errors that may arise in working with `JSON`.
-    public enum Error: ErrorProtocol {
+    public enum JSONError: Error {
         /// The `index` is out of bounds for a JSON array
         case indexOutOfBounds(index: Swift.Int)
         

--- a/Sources/JSON.swift
+++ b/Sources/JSON.swift
@@ -29,7 +29,7 @@ public enum JSON {
 extension JSON {
 
     /// An enum to encapsulate errors that may arise in working with `JSON`.
-    public enum JSONError: Error {
+    public enum Error: ErrorProtocol {
         /// The `index` is out of bounds for a JSON array
         case indexOutOfBounds(index: Swift.Int)
         

--- a/Sources/JSONDecodable.swift
+++ b/Sources/JSONDecodable.swift
@@ -33,7 +33,7 @@ extension Double: JSONDecodable {
         case let .Int(int):
             self = Swift.Double(int)
         default:
-            throw JSON.JSONError.valueNotConvertible(value: json, to: Swift.Double)
+            throw JSON.Error.valueNotConvertible(value: json, to: Swift.Double)
         }
     }
     
@@ -53,7 +53,7 @@ extension Int: JSONDecodable {
         case let .Int(int):
             self = int
         default:
-            throw JSON.JSONError.valueNotConvertible(value: json, to: Swift.Int)
+            throw JSON.Error.valueNotConvertible(value: json, to: Swift.Int)
         }
     }
     
@@ -68,7 +68,7 @@ extension String: JSONDecodable {
     ///           passed to this initializer.
     public init(json: JSON) throws {
         guard case let .String(string) = json else {
-            throw JSON.JSONError.valueNotConvertible(value: json, to: Swift.String)
+            throw JSON.Error.valueNotConvertible(value: json, to: Swift.String)
         }
         self = string
     }
@@ -84,7 +84,7 @@ extension Bool: JSONDecodable {
     ///           passed to this initializer.
     public init(json: JSON) throws {
         guard case let .Bool(bool) = json else {
-            throw JSON.JSONError.valueNotConvertible(value: json, to: Swift.Bool)
+            throw JSON.Error.valueNotConvertible(value: json, to: Swift.Bool)
         }
         self = bool
     }
@@ -101,7 +101,7 @@ extension RawRepresentable where RawValue: JSONDecodable {
     public init(json: JSON) throws {
         let raw = try json.decode(type: RawValue.self)
         guard let value = Self(rawValue: raw) else {
-            throw JSON.JSONError.valueNotConvertible(value: json, to: Self.self)
+            throw JSON.Error.valueNotConvertible(value: json, to: Self.self)
         }
         self = value
     }
@@ -117,7 +117,7 @@ internal extension JSON {
     static func getArray(_ json: JSON) throws -> [JSON] {
         // Ideally should be expressed as a conditional protocol implementation on Swift.Array.
         guard case let .Array(array) = json else {
-            throw JSONError.valueNotConvertible(value: json, to: Swift.Array<JSON>)
+            throw Error.valueNotConvertible(value: json, to: Swift.Array<JSON>)
         }
         return array
     }
@@ -130,7 +130,7 @@ internal extension JSON {
     static func getDictionary(_ json: JSON) throws -> [Swift.String: JSON] {
         // Ideally should be expressed as a conditional protocol implementation on Swift.Dictionary.
         guard case let .Dictionary(dictionary) = json else {
-            throw JSONError.valueNotConvertible(value: json, to: Swift.Dictionary<Swift.String, JSON>)
+            throw Error.valueNotConvertible(value: json, to: Swift.Dictionary<Swift.String, JSON>)
         }
         return dictionary
     }
@@ -156,7 +156,7 @@ internal extension JSON {
     /// - seealso: `JSON.decode(_:type:)`
     static func getDictionaryOf<Decoded: JSONDecodable>(_ json: JSON) throws -> [Swift.String: Decoded] {
         guard case let .Dictionary(dictionary) = json else {
-            throw JSONError.valueNotConvertible(value: json, to: Swift.Dictionary<Swift.String, Decoded>)
+            throw Error.valueNotConvertible(value: json, to: Swift.Dictionary<Swift.String, Decoded>)
         }
         var decodedDictionary = Swift.Dictionary<Swift.String, Decoded>(minimumCapacity: dictionary.count)
         for (key, value) in dictionary {

--- a/Sources/JSONDecodable.swift
+++ b/Sources/JSONDecodable.swift
@@ -33,7 +33,7 @@ extension Double: JSONDecodable {
         case let .Int(int):
             self = Swift.Double(int)
         default:
-            throw JSON.Error.valueNotConvertible(value: json, to: Swift.Double)
+            throw JSON.JSONError.valueNotConvertible(value: json, to: Swift.Double)
         }
     }
     
@@ -53,7 +53,7 @@ extension Int: JSONDecodable {
         case let .Int(int):
             self = int
         default:
-            throw JSON.Error.valueNotConvertible(value: json, to: Swift.Int)
+            throw JSON.JSONError.valueNotConvertible(value: json, to: Swift.Int)
         }
     }
     
@@ -68,7 +68,7 @@ extension String: JSONDecodable {
     ///           passed to this initializer.
     public init(json: JSON) throws {
         guard case let .String(string) = json else {
-            throw JSON.Error.valueNotConvertible(value: json, to: Swift.String)
+            throw JSON.JSONError.valueNotConvertible(value: json, to: Swift.String)
         }
         self = string
     }
@@ -84,7 +84,7 @@ extension Bool: JSONDecodable {
     ///           passed to this initializer.
     public init(json: JSON) throws {
         guard case let .Bool(bool) = json else {
-            throw JSON.Error.valueNotConvertible(value: json, to: Swift.Bool)
+            throw JSON.JSONError.valueNotConvertible(value: json, to: Swift.Bool)
         }
         self = bool
     }
@@ -101,7 +101,7 @@ extension RawRepresentable where RawValue: JSONDecodable {
     public init(json: JSON) throws {
         let raw = try json.decode(type: RawValue.self)
         guard let value = Self(rawValue: raw) else {
-            throw JSON.Error.valueNotConvertible(value: json, to: Self.self)
+            throw JSON.JSONError.valueNotConvertible(value: json, to: Self.self)
         }
         self = value
     }
@@ -117,7 +117,7 @@ internal extension JSON {
     static func getArray(_ json: JSON) throws -> [JSON] {
         // Ideally should be expressed as a conditional protocol implementation on Swift.Array.
         guard case let .Array(array) = json else {
-            throw Error.valueNotConvertible(value: json, to: Swift.Array<JSON>)
+            throw JSONError.valueNotConvertible(value: json, to: Swift.Array<JSON>)
         }
         return array
     }
@@ -130,7 +130,7 @@ internal extension JSON {
     static func getDictionary(_ json: JSON) throws -> [Swift.String: JSON] {
         // Ideally should be expressed as a conditional protocol implementation on Swift.Dictionary.
         guard case let .Dictionary(dictionary) = json else {
-            throw Error.valueNotConvertible(value: json, to: Swift.Dictionary<Swift.String, JSON>)
+            throw JSONError.valueNotConvertible(value: json, to: Swift.Dictionary<Swift.String, JSON>)
         }
         return dictionary
     }
@@ -156,7 +156,7 @@ internal extension JSON {
     /// - seealso: `JSON.decode(_:type:)`
     static func getDictionaryOf<Decoded: JSONDecodable>(_ json: JSON) throws -> [Swift.String: Decoded] {
         guard case let .Dictionary(dictionary) = json else {
-            throw Error.valueNotConvertible(value: json, to: Swift.Dictionary<Swift.String, Decoded>)
+            throw JSONError.valueNotConvertible(value: json, to: Swift.Dictionary<Swift.String, Decoded>)
         }
         var decodedDictionary = Swift.Dictionary<Swift.String, Decoded>(minimumCapacity: dictionary.count)
         for (key, value) in dictionary {

--- a/Sources/JSONParser.swift
+++ b/Sources/JSONParser.swift
@@ -832,7 +832,7 @@ extension JSONParser {
     /// document. Most errors include an associated `offset`, representing the
     /// offset into the UTF-8 characters making up the document where the error
     /// occurred.
-    public enum Error: ErrorProtocol {
+    public enum Error: Swift.Error {
         /// The parser ran out of data prematurely. This usually means a value
         /// was not escaped, such as a string literal not ending with a double
         /// quote.
@@ -887,7 +887,7 @@ extension JSONParser {
         case invalidUnicodeStreamEncoding(detectedEncoding: JSONEncodingDetector.Encoding)
     }
 
-    private enum InternalError: ErrorProtocol {
+    private enum InternalError: Swift.Error {
         /// Attempted to parse an integer outside the range of [Int.min, Int.max]
         /// or a double outside the range of representable doubles. Note that
         /// for doubles, this could be an overflow or an underflow - we don't

--- a/Sources/JSONParser.swift
+++ b/Sources/JSONParser.swift
@@ -100,18 +100,18 @@ public struct JSONParser {
         let value = try parseValue()
         skipWhitespace()
         guard loc == input.count else {
-            throw ParserError.endOfStreamGarbage(offset: loc)
+            throw Error.endOfStreamGarbage(offset: loc)
         }
         return value
     }
 
     private mutating func parseValue() throws -> JSON {
         guard depth <= ParserMaximumDepth else {
-            throw ParserError.exceededNestingLimit(offset: loc)
+            throw Error.exceededNestingLimit(offset: loc)
         }
         
         guard input.count > 0 else {
-            throw ParserError.endOfStreamUnexpected
+            throw Error.endOfStreamUnexpected
         }
 
         advancing: while loc < input.count {
@@ -159,7 +159,7 @@ public struct JSONParser {
             }
         }
         
-        throw ParserError.valueInvalid(offset: loc, character: UnicodeScalar(input[loc]))
+        throw Error.valueInvalid(offset: loc, character: UnicodeScalar(input[loc]))
     }
 
     private mutating func skipWhitespace() {
@@ -178,20 +178,20 @@ public struct JSONParser {
         let header = input.prefix(4)
         let encodingPrefixInformation = JSONEncodingDetector.detectEncoding(header)
         guard JSONEncodingDetector.supportedEncodings.contains(encodingPrefixInformation.encoding) else {
-            throw ParserError.invalidUnicodeStreamEncoding(detectedEncoding: encodingPrefixInformation.encoding)
+            throw Error.invalidUnicodeStreamEncoding(detectedEncoding: encodingPrefixInformation.encoding)
         }
         loc = loc.advanced(by: encodingPrefixInformation.byteOrderMarkLength)
     }
 
     private mutating func decodeNull() throws -> JSON {
         guard input.index(loc, offsetBy: 3, limitedBy: input.count) != input.count else {
-            throw ParserError.literalNilMisspelled(offset: loc)
+            throw Error.literalNilMisspelled(offset: loc)
         }
 
         if     input[loc+1] != Literal.u
             || input[loc+2] != Literal.l
             || input[loc+3] != Literal.l {
-                throw ParserError.literalNilMisspelled(offset: loc)
+                throw Error.literalNilMisspelled(offset: loc)
         }
 
         loc += 4
@@ -200,13 +200,13 @@ public struct JSONParser {
 
     private mutating func decodeTrue() throws -> JSON {
         guard input.index(loc, offsetBy: 3, limitedBy: input.count) != input.count else {
-            throw ParserError.literalNilMisspelled(offset: loc)
+            throw Error.literalNilMisspelled(offset: loc)
         }
 
         if     input[loc+1] != Literal.r
             || input[loc+2] != Literal.u
             || input[loc+3] != Literal.e {
-            throw ParserError.literalTrueMisspelled(offset: loc)
+            throw Error.literalTrueMisspelled(offset: loc)
         }
 
         loc += 4
@@ -215,14 +215,14 @@ public struct JSONParser {
 
     private mutating func decodeFalse() throws -> JSON {
         guard input.index(loc, offsetBy: 4, limitedBy: input.count) != input.count else {
-            throw ParserError.literalNilMisspelled(offset: loc)
+            throw Error.literalNilMisspelled(offset: loc)
         }
 
         if     input[loc+1] != Literal.a
             || input[loc+2] != Literal.l
             || input[loc+3] != Literal.s
             || input[loc+4] != Literal.e {
-            throw ParserError.literalFalseMisspelled(offset: loc)
+            throw Error.literalFalseMisspelled(offset: loc)
         }
 
         loc += 5
@@ -255,7 +255,7 @@ public struct JSONParser {
                     continue
 
                 default:
-                    throw ParserError.controlCharacterUnrecognized(offset: loc)
+                    throw Error.controlCharacterUnrecognized(offset: loc)
                 }
                 loc = (loc + 1)
 
@@ -275,7 +275,7 @@ public struct JSONParser {
             }
         }
 
-        throw ParserError.endOfStreamUnexpected
+        throw Error.endOfStreamUnexpected
     }
 
     private mutating func readCodeUnit() -> UInt16? {
@@ -307,7 +307,7 @@ public struct JSONParser {
 
     private mutating func readUnicodeEscape(start: Int) throws {
         guard let codeUnit = readCodeUnit() else {
-            throw ParserError.unicodeEscapeInvalid(offset: start)
+            throw Error.unicodeEscapeInvalid(offset: start)
         }
 
         let codeUnits: [UInt16]
@@ -317,13 +317,13 @@ public struct JSONParser {
 
             // First confirm and skip over that we have another "\u"
             guard loc + 6 <= input.count && input[loc] == Literal.BACKSLASH && input[loc+1] == Literal.u else {
-                throw ParserError.unicodeEscapeInvalid(offset: start)
+                throw Error.unicodeEscapeInvalid(offset: start)
             }
             loc += 2
 
             // Ensure the second code unit is valid for the surrogate pair
             guard let secondCodeUnit = readCodeUnit() where UTF16.isTrailSurrogate(secondCodeUnit) else {
-                throw ParserError.unicodeEscapeInvalid(offset: start)
+                throw Error.unicodeEscapeInvalid(offset: start)
             }
 
             codeUnits = [codeUnit, secondCodeUnit]
@@ -336,7 +336,7 @@ public struct JSONParser {
         }
 
         if transcodeHadError {
-            throw ParserError.unicodeEscapeInvalid(offset: start)
+            throw Error.unicodeEscapeInvalid(offset: start)
         }
     }
 
@@ -355,7 +355,7 @@ public struct JSONParser {
 
             if !items.isEmpty {
                 guard loc < input.count && input[loc] == Literal.COMMA else {
-                    throw ParserError.collectionMissingSeparator(offset: start)
+                    throw Error.collectionMissingSeparator(offset: start)
                 }
                 loc = (loc + 1)
             }
@@ -363,7 +363,7 @@ public struct JSONParser {
             items.append(try parseValue())
         }
 
-        throw ParserError.endOfStreamUnexpected
+        throw Error.endOfStreamUnexpected
     }
 
     // Decoding objects can be recursive, so we have to keep more than one
@@ -412,7 +412,7 @@ public struct JSONParser {
 
             if !pairs.isEmpty {
                 guard loc < input.count && input[loc] == Literal.COMMA else {
-                    throw ParserError.collectionMissingSeparator(offset: start)
+                    throw Error.collectionMissingSeparator(offset: start)
                 }
                 loc = (loc + 1)
 
@@ -420,21 +420,21 @@ public struct JSONParser {
             }
 
             guard loc < input.count && input[loc] == Literal.DOUBLE_QUOTE else {
-                throw ParserError.dictionaryMissingKey(offset: start)
+                throw Error.dictionaryMissingKey(offset: start)
             }
 
             let key = try decodeString().string()
             skipWhitespace()
 
             guard loc < input.count && input[loc] == Literal.COLON else {
-                throw ParserError.collectionMissingSeparator(offset: start)
+                throw Error.collectionMissingSeparator(offset: start)
             }
             loc = (loc + 1)
 
             pairs.append((key, try parseValue()))
         }
 
-        throw ParserError.endOfStreamUnexpected
+        throw Error.endOfStreamUnexpected
     }
 
     private mutating func decodeIntegralValue(_ parser: NumberParser) throws -> JSON {
@@ -630,7 +630,7 @@ private struct NumberParser {
 
         loc = (loc + 1)
         guard loc < input.count else {
-            throw JSONParser.ParserError.endOfStreamUnexpected
+            throw JSONParser.Error.endOfStreamUnexpected
         }
 
         switch input[loc] {
@@ -641,7 +641,7 @@ private struct NumberParser {
             state = .preDecimalDigits
 
         default:
-            throw JSONParser.ParserError.numberSymbolMissingDigits(offset: start)
+            throw JSONParser.Error.numberSymbolMissingDigits(offset: start)
         }
     }
 
@@ -691,7 +691,7 @@ private struct NumberParser {
         assert(state == .decimal, "Unexpected state entering parseDecimal")
         loc = (loc + 1)
         guard loc < input.count else {
-            throw JSONParser.ParserError.endOfStreamUnexpected
+            throw JSONParser.Error.endOfStreamUnexpected
         }
 
         switch input[loc] {
@@ -699,7 +699,7 @@ private struct NumberParser {
             state = .postDecimalDigits
 
         default:
-            throw JSONParser.ParserError.numberMissingFractionalDigits(offset: start)
+            throw JSONParser.Error.numberMissingFractionalDigits(offset: start)
         }
     }
 
@@ -730,7 +730,7 @@ private struct NumberParser {
 
         loc = (loc + 1)
         guard loc < input.count else {
-            throw JSONParser.ParserError.endOfStreamUnexpected
+            throw JSONParser.Error.endOfStreamUnexpected
         }
 
         switch input[loc] {
@@ -745,7 +745,7 @@ private struct NumberParser {
             return .negative
 
         default:
-            throw JSONParser.ParserError.numberSymbolMissingDigits(offset: start)
+            throw JSONParser.Error.numberSymbolMissingDigits(offset: start)
         }
 
         return .positive
@@ -755,7 +755,7 @@ private struct NumberParser {
         assert(state == .exponentSign, "Unexpected state entering parseExponentSign")
         loc = (loc + 1)
         guard loc < input.count else {
-            throw JSONParser.ParserError.endOfStreamUnexpected
+            throw JSONParser.Error.endOfStreamUnexpected
         }
 
         switch input[loc] {
@@ -763,7 +763,7 @@ private struct NumberParser {
             state = .exponentDigits
 
         default:
-            throw JSONParser.ParserError.numberSymbolMissingDigits(offset: start)
+            throw JSONParser.Error.numberSymbolMissingDigits(offset: start)
         }
     }
 
@@ -832,7 +832,7 @@ extension JSONParser {
     /// document. Most errors include an associated `offset`, representing the
     /// offset into the UTF-8 characters making up the document where the error
     /// occurred.
-    public enum ParserError: Error {
+    public enum Error: ErrorProtocol {
         /// The parser ran out of data prematurely. This usually means a value
         /// was not escaped, such as a string literal not ending with a double
         /// quote.
@@ -887,7 +887,7 @@ extension JSONParser {
         case invalidUnicodeStreamEncoding(detectedEncoding: JSONEncodingDetector.Encoding)
     }
 
-    private enum InternalError: Error {
+    private enum InternalError: ErrorProtocol {
         /// Attempted to parse an integer outside the range of [Int.min, Int.max]
         /// or a double outside the range of representable doubles. Note that
         /// for doubles, this could be an overflow or an underflow - we don't

--- a/Sources/JSONSubscripting.swift
+++ b/Sources/JSONSubscripting.swift
@@ -35,13 +35,13 @@ extension JSONPathType {
     /// The default behavior for keying into a dictionary is to throw
     /// `JSON.Error.UnexpectedSubscript`.
     public func valueInDictionary(_ dictionary: [Swift.String : JSON]) throws -> JSON {
-        throw JSON.Error.unexpectedSubscript(type: Self.self)
+        throw JSON.JSONError.unexpectedSubscript(type: Self.self)
     }
 
     /// The default behavior for indexing into an array is to throw
     /// `JSON.Error.UnexpectedSubscript`.
     public func valueInArray(_ array: [JSON]) throws -> JSON {
-        throw JSON.Error.unexpectedSubscript(type: Self.self)
+        throw JSON.JSONError.unexpectedSubscript(type: Self.self)
     }
 
 }
@@ -55,7 +55,7 @@ extension String: JSONPathType {
     /// - returns: The `JSON` value associated with the given key.
     public func valueInDictionary(_ dictionary: [Swift.String : JSON]) throws -> JSON {
         guard let next = dictionary[self] else {
-            throw JSON.Error.keyNotFound(key: self)
+            throw JSON.JSONError.keyNotFound(key: self)
         }
         return next
     }
@@ -71,7 +71,7 @@ extension Int: JSONPathType {
     /// - returns: The `JSON` value found at the given index.
     public func valueInArray(_ array: [JSON]) throws -> JSON {
         guard case array.indices = self else {
-            throw JSON.Error.indexOutOfBounds(index: self)
+            throw JSON.JSONError.indexOutOfBounds(index: self)
         }
         return array[self]
     }
@@ -82,7 +82,7 @@ extension Int: JSONPathType {
 
 private extension JSON {
 
-    enum SubscriptError: ErrorProtocol {
+    enum SubscriptError: Error {
         case subscriptIntoNull(JSONPathType)
     }
 
@@ -95,7 +95,7 @@ private extension JSON {
         case let .Array(array):
             return try fragment.valueInArray(array)
         default:
-            throw Error.unexpectedSubscript(type: fragment.dynamicType)
+            throw JSONError.unexpectedSubscript(type: fragment.dynamicType)
         }
     }
 
@@ -256,11 +256,11 @@ extension JSON {
         do {
             json = try valueAtPath(path, detectNull: detectNull)
             return try json.map(transform)
-        } catch Error.indexOutOfBounds where detectNotFound {
+        } catch JSONError.indexOutOfBounds where detectNotFound {
             return nil
-        } catch Error.keyNotFound where detectNotFound {
+        } catch JSONError.keyNotFound where detectNotFound {
             return nil
-        } catch Error.valueNotConvertible where detectNull && json == .null {
+        } catch JSONError.valueNotConvertible where detectNull && json == .null {
             return nil
         } catch SubscriptError.subscriptIntoNull where detectNull {
             return nil

--- a/Sources/JSONSubscripting.swift
+++ b/Sources/JSONSubscripting.swift
@@ -82,7 +82,7 @@ extension Int: JSONPathType {
 
 private extension JSON {
 
-    enum SubscriptError: ErrorProtocol {
+    enum SubscriptError: Swift.Error {
         case subscriptIntoNull(JSONPathType)
     }
 

--- a/Sources/JSONSubscripting.swift
+++ b/Sources/JSONSubscripting.swift
@@ -35,13 +35,13 @@ extension JSONPathType {
     /// The default behavior for keying into a dictionary is to throw
     /// `JSON.Error.UnexpectedSubscript`.
     public func valueInDictionary(_ dictionary: [Swift.String : JSON]) throws -> JSON {
-        throw JSON.JSONError.unexpectedSubscript(type: Self.self)
+        throw JSON.Error.unexpectedSubscript(type: Self.self)
     }
 
     /// The default behavior for indexing into an array is to throw
     /// `JSON.Error.UnexpectedSubscript`.
     public func valueInArray(_ array: [JSON]) throws -> JSON {
-        throw JSON.JSONError.unexpectedSubscript(type: Self.self)
+        throw JSON.Error.unexpectedSubscript(type: Self.self)
     }
 
 }
@@ -55,7 +55,7 @@ extension String: JSONPathType {
     /// - returns: The `JSON` value associated with the given key.
     public func valueInDictionary(_ dictionary: [Swift.String : JSON]) throws -> JSON {
         guard let next = dictionary[self] else {
-            throw JSON.JSONError.keyNotFound(key: self)
+            throw JSON.Error.keyNotFound(key: self)
         }
         return next
     }
@@ -71,7 +71,7 @@ extension Int: JSONPathType {
     /// - returns: The `JSON` value found at the given index.
     public func valueInArray(_ array: [JSON]) throws -> JSON {
         guard case array.indices = self else {
-            throw JSON.JSONError.indexOutOfBounds(index: self)
+            throw JSON.Error.indexOutOfBounds(index: self)
         }
         return array[self]
     }
@@ -82,7 +82,7 @@ extension Int: JSONPathType {
 
 private extension JSON {
 
-    enum SubscriptError: Error {
+    enum SubscriptError: ErrorProtocol {
         case subscriptIntoNull(JSONPathType)
     }
 
@@ -95,7 +95,7 @@ private extension JSON {
         case let .Array(array):
             return try fragment.valueInArray(array)
         default:
-            throw JSONError.unexpectedSubscript(type: fragment.dynamicType)
+            throw Error.unexpectedSubscript(type: fragment.dynamicType)
         }
     }
 
@@ -256,11 +256,11 @@ extension JSON {
         do {
             json = try valueAtPath(path, detectNull: detectNull)
             return try json.map(transform)
-        } catch JSONError.indexOutOfBounds where detectNotFound {
+        } catch Error.indexOutOfBounds where detectNotFound {
             return nil
-        } catch JSONError.keyNotFound where detectNotFound {
+        } catch Error.keyNotFound where detectNotFound {
             return nil
-        } catch JSONError.valueNotConvertible where detectNull && json == .null {
+        } catch Error.valueNotConvertible where detectNull && json == .null {
             return nil
         } catch SubscriptError.subscriptIntoNull where detectNull {
             return nil


### PR DESCRIPTION
- Renamed JSON.Error to JSON.JSONError to avoid conflict with Error type in swift 3 with Xcode 8 beta 4
- Renamed JSONParser.Error to JSONParser.ParserError to avoid conflict with Error type in swift 3 with Xcode 8 beta 4