### PR TITLE
WIP: First draft at a possible JSONValueTransformer protocol

### DIFF
--- a/Freddy.xcodeproj/project.pbxproj
+++ b/Freddy.xcodeproj/project.pbxproj
@@ -20,6 +20,11 @@
 		3F70EA981C6D0EC500972CEB /* JSONSerializingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F70EA971C6D0EC500972CEB /* JSONSerializingTests.swift */; };
 		3F70EA991C6D0EC500972CEB /* JSONSerializingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F70EA971C6D0EC500972CEB /* JSONSerializingTests.swift */; };
 		3F70EA9A1C6D0EC500972CEB /* JSONSerializingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F70EA971C6D0EC500972CEB /* JSONSerializingTests.swift */; };
+		525091AD1D54D787003F08C6 /* JSONValueTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 525091AC1D54D787003F08C6 /* JSONValueTransformer.swift */; };
+		525091BD1D54DFAC003F08C6 /* JSONTransformerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 525091BC1D54DFAC003F08C6 /* JSONTransformerTests.swift */; };
+		52CCB93B1D5514180009E564 /* JSONValueTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 525091AC1D54D787003F08C6 /* JSONValueTransformer.swift */; };
+		52CCB93C1D5514190009E564 /* JSONValueTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 525091AC1D54D787003F08C6 /* JSONValueTransformer.swift */; };
+		52CCB93D1D5514190009E564 /* JSONValueTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 525091AC1D54D787003F08C6 /* JSONValueTransformer.swift */; };
 		DB6ADF231C23610B00D77BF1 /* Freddy.h in Headers */ = {isa = PBXBuildFile; fileRef = DB6ADF221C23610B00D77BF1 /* Freddy.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DB6ADF2A1C23610B00D77BF1 /* Freddy.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB6ADF1F1C23610B00D77BF1 /* Freddy.framework */; };
 		DB6ADF481C23612000D77BF1 /* Freddy.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB6ADF3E1C23612000D77BF1 /* Freddy.framework */; };
@@ -109,6 +114,8 @@
 		1C7BD51E1C7A4B9300A6ED4B /* JSONSubscriptingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONSubscriptingTests.swift; sourceTree = "<group>"; };
 		3F70EA921C6D0D2B00972CEB /* JSONSerializing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONSerializing.swift; sourceTree = "<group>"; };
 		3F70EA971C6D0EC500972CEB /* JSONSerializingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONSerializingTests.swift; sourceTree = "<group>"; };
+		525091AC1D54D787003F08C6 /* JSONValueTransformer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONValueTransformer.swift; sourceTree = "<group>"; };
+		525091BC1D54DFAC003F08C6 /* JSONTransformerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONTransformerTests.swift; sourceTree = "<group>"; };
 		DB6ADF1F1C23610B00D77BF1 /* Freddy.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Freddy.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DB6ADF221C23610B00D77BF1 /* Freddy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Freddy.h; sourceTree = "<group>"; };
 		DB6ADF241C23610B00D77BF1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -234,6 +241,7 @@
 				3F70EA921C6D0D2B00972CEB /* JSONSerializing.swift */,
 				DB6ADF8F1C2362E000D77BF1 /* JSONSubscripting.swift */,
 				E43B67DA1C59598700ACE390 /* JSONEncodingDetector.swift */,
+				525091AC1D54D787003F08C6 /* JSONValueTransformer.swift */,
 				DB6ADF241C23610B00D77BF1 /* Info.plist */,
 			);
 			name = Freddy;
@@ -249,6 +257,7 @@
 				DB6ADFAD1C2362FF00D77BF1 /* JSONParserTests.swift */,
 				3F70EA971C6D0EC500972CEB /* JSONSerializingTests.swift */,
 				1C7BD51E1C7A4B9300A6ED4B /* JSONSubscriptingTests.swift */,
+				525091BC1D54DFAC003F08C6 /* JSONTransformerTests.swift */,
 				DB6ADFAF1C2362FF00D77BF1 /* JSONTypeTests.swift */,
 				E43B67DF1C5962CD00ACE390 /* JSONEncodingDetectorTests.swift */,
 				DB6ADFC01C23630500D77BF1 /* Fixtures */,
@@ -566,6 +575,7 @@
 				3F70EA941C6D0D3000972CEB /* JSONSerializing.swift in Sources */,
 				DB6ADF911C2362E000D77BF1 /* JSON.swift in Sources */,
 				DB6ADFA91C2362E000D77BF1 /* JSONSubscripting.swift in Sources */,
+				52CCB93B1D5514180009E564 /* JSONValueTransformer.swift in Sources */,
 				DB6ADFA11C2362E000D77BF1 /* JSONParsing.swift in Sources */,
 				DB6ADF991C2362E000D77BF1 /* JSONLiteralConvertible.swift in Sources */,
 				1C67C7271C3B27DA003D5A05 /* JSONEncodable.swift in Sources */,
@@ -595,6 +605,7 @@
 				3F70EA931C6D0D2B00972CEB /* JSONSerializing.swift in Sources */,
 				DB6ADF901C2362E000D77BF1 /* JSON.swift in Sources */,
 				DB6ADFA81C2362E000D77BF1 /* JSONSubscripting.swift in Sources */,
+				525091AD1D54D787003F08C6 /* JSONValueTransformer.swift in Sources */,
 				DB6ADFA01C2362E000D77BF1 /* JSONParsing.swift in Sources */,
 				DB6ADF981C2362E000D77BF1 /* JSONLiteralConvertible.swift in Sources */,
 				1C67C7261C3B2446003D5A05 /* JSONEncodable.swift in Sources */,
@@ -617,6 +628,7 @@
 				E43B67E01C5962CD00ACE390 /* JSONEncodingDetectorTests.swift in Sources */,
 				DB6ADFB11C2362FF00D77BF1 /* JSONDecodableTests.swift in Sources */,
 				DC194EB91C47D87B001D4569 /* JSONTests.swift in Sources */,
+				525091BD1D54DFAC003F08C6 /* JSONTransformerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -627,6 +639,7 @@
 				3F70EA951C6D0D3100972CEB /* JSONSerializing.swift in Sources */,
 				DB6ADF921C2362E000D77BF1 /* JSON.swift in Sources */,
 				DB6ADFAA1C2362E000D77BF1 /* JSONSubscripting.swift in Sources */,
+				52CCB93C1D5514190009E564 /* JSONValueTransformer.swift in Sources */,
 				DB6ADFA21C2362E000D77BF1 /* JSONParsing.swift in Sources */,
 				DB6ADF9A1C2362E000D77BF1 /* JSONLiteralConvertible.swift in Sources */,
 				1C67C7281C3B27DC003D5A05 /* JSONEncodable.swift in Sources */,
@@ -656,6 +669,7 @@
 				3F70EA961C6D0D3200972CEB /* JSONSerializing.swift in Sources */,
 				DB6ADF931C2362E000D77BF1 /* JSON.swift in Sources */,
 				DB6ADFAB1C2362E000D77BF1 /* JSONSubscripting.swift in Sources */,
+				52CCB93D1D5514190009E564 /* JSONValueTransformer.swift in Sources */,
 				DB6ADFA31C2362E000D77BF1 /* JSONParsing.swift in Sources */,
 				DB6ADF9B1C2362E000D77BF1 /* JSONLiteralConvertible.swift in Sources */,
 				1C67C7291C3B27DD003D5A05 /* JSONEncodable.swift in Sources */,

--- a/Sources/JSONSubscripting.swift
+++ b/Sources/JSONSubscripting.swift
@@ -146,6 +146,11 @@ extension JSON {
         return try Decoded(json: valueAtPath(path))
     }
 
+    public func transformed<Transformer: JSONValueTransformer where Transformer.In == Swift.String>(path: JSONPathType..., transformer: Transformer) throws -> Transformer.Out {
+        let s = try Swift.String(json: valueAtPath(path))
+        return try transformer.transformValue(s)
+    }
+
     /// Retrieves a `Double` from a path into JSON.
     /// - parameter path: 0 or more `String` or `Int` that subscript the `JSON`
     /// - returns: A floating-point `Double`

--- a/Sources/JSONSubscripting.swift
+++ b/Sources/JSONSubscripting.swift
@@ -146,9 +146,8 @@ extension JSON {
         return try Decoded(json: valueAtPath(path))
     }
 
-    public func transformed<Transformer: JSONValueTransformer where Transformer.In == Swift.String>(path: JSONPathType..., transformer: Transformer) throws -> Transformer.Out {
-        let s = try Swift.String(json: valueAtPath(path))
-        return try transformer.transformValue(s)
+    public func transformed<Transformer: JSONValueTransformer>(path: JSONPathType..., transformer: Transformer) throws -> Transformer.Out {
+        return try transformer.transformed(valueAtPath(path))
     }
 
     /// Retrieves a `Double` from a path into JSON.

--- a/Sources/JSONValueTransformer.swift
+++ b/Sources/JSONValueTransformer.swift
@@ -1,0 +1,77 @@
+//
+//  JSONValueTransformer.swift
+//  Freddy
+//
+//  Created by John Gallagher on 8/5/16.
+//  Copyright © 2016 Big Nerd Ranch. All rights reserved.
+//
+
+import Foundation
+
+public enum JSONValueTransformerError: ErrorType {
+    case InvalidInputType
+}
+
+public protocol JSONValueTransformer {
+    associatedtype In
+    associatedtype Out
+
+    func transformValue(value: In) throws -> Out
+}
+
+public struct JSONDateTransformer {
+    public enum Error: ErrorType {
+        case InvalidValue(String)
+    }
+
+    public enum ISO8601: String {
+        case WithoutTimeZone                  = "yyyy-MM-dd'T'HH:mm:ss"
+        case WithTimeZone                     = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
+        case WithTimeZoneAndFractionalSeconds = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
+    }
+
+    private let formatter: NSDateFormatter
+
+    public init(iso8601: ISO8601) {
+        self.init(dateFormat: iso8601.rawValue)
+    }
+
+    public init(dateFormat: String) {
+        let formatter = NSDateFormatter()
+        formatter.dateFormat = dateFormat
+        formatter.timeZone = NSTimeZone(forSecondsFromGMT: 0)
+        formatter.locale = NSLocale(localeIdentifier: "en_US_POSIX")
+        formatter.calendar = NSCalendar(identifier: NSCalendarIdentifierISO8601)
+        self.init(formatter: formatter)
+    }
+
+    public init(formatter: NSDateFormatter) {
+        self.formatter = formatter
+    }
+}
+
+extension JSONDateTransformer: JSONValueTransformer {
+    public func transformValue(value: String) throws -> NSDate {
+        guard let date = formatter.dateFromString(value) else {
+            throw Error.InvalidValue(value)
+        }
+
+        return date
+    }
+}
+
+public struct JSONTransformerChainLink<TransformerIn: JSONValueTransformer, TransformerOut: JSONValueTransformer where TransformerIn.Out == TransformerOut.In> {
+    private let transformerIn: TransformerIn
+    private let transformerOut: TransformerOut
+
+    public init(from transformerIn: TransformerIn, to transformerOut: TransformerOut) {
+        self.transformerIn = transformerIn
+        self.transformerOut = transformerOut
+    }
+}
+
+extension JSONTransformerChainLink: JSONValueTransformer {
+    public func transformValue(value: TransformerIn.In) throws -> TransformerOut.Out {
+        return try transformerOut.transformValue(transformerIn.transformValue(value))
+    }
+}

--- a/Sources/JSONValueTransformer.swift
+++ b/Sources/JSONValueTransformer.swift
@@ -13,10 +13,9 @@ public enum JSONValueTransformerError: ErrorType {
 }
 
 public protocol JSONValueTransformer {
-    associatedtype In
     associatedtype Out
 
-    func transformValue(value: In) throws -> Out
+    func transformed(value: JSON) throws -> Out
 }
 
 public struct JSONDateTransformer {
@@ -51,27 +50,12 @@ public struct JSONDateTransformer {
 }
 
 extension JSONDateTransformer: JSONValueTransformer {
-    public func transformValue(value: String) throws -> NSDate {
-        guard let date = formatter.dateFromString(value) else {
-            throw Error.InvalidValue(value)
+    public func transformed(value: JSON) throws -> NSDate {
+        let s = try value.string()
+        guard let date = formatter.dateFromString(s) else {
+            throw Error.InvalidValue(s)
         }
 
         return date
-    }
-}
-
-public struct JSONTransformerChainLink<TransformerIn: JSONValueTransformer, TransformerOut: JSONValueTransformer where TransformerIn.Out == TransformerOut.In> {
-    private let transformerIn: TransformerIn
-    private let transformerOut: TransformerOut
-
-    public init(from transformerIn: TransformerIn, to transformerOut: TransformerOut) {
-        self.transformerIn = transformerIn
-        self.transformerOut = transformerOut
-    }
-}
-
-extension JSONTransformerChainLink: JSONValueTransformer {
-    public func transformValue(value: TransformerIn.In) throws -> TransformerOut.Out {
-        return try transformerOut.transformValue(transformerIn.transformValue(value))
     }
 }

--- a/Tests/JSONTransformerTests.swift
+++ b/Tests/JSONTransformerTests.swift
@@ -30,27 +30,4 @@ class JSONTransformerTests: XCTestCase {
         }
     }
 
-    struct MyDateContainer {
-        let date: NSDate
-    }
-
-    struct MyDateContainerTransformer: JSONValueTransformer {
-        func transformValue(value: NSDate) throws -> MyDateContainer {
-            return MyDateContainer(date: value)
-        }
-    }
-
-    func testTransformerChainLink() {
-        let (s, expectedDate, format) = dateTestData[0]
-        let json = JSON.String(s)
-        let transformer = JSONTransformerChainLink(from: JSONDateTransformer(iso8601: format), to: MyDateContainerTransformer())
-        do {
-            let container = try json.transformed(transformer: transformer)
-            let diff = container.date.timeIntervalSinceDate(expectedDate)
-            XCTAssertEqualWithAccuracy(diff, 0, accuracy: 0.01)
-        } catch {
-            XCTFail("Unexpected error \(error)")
-        }
-    }
-
 }

--- a/Tests/JSONTransformerTests.swift
+++ b/Tests/JSONTransformerTests.swift
@@ -1,0 +1,56 @@
+//
+//  JSONTransformerTests.swift
+//  Freddy
+//
+//  Created by John Gallagher on 8/5/16.
+//  Copyright © 2016 Big Nerd Ranch. All rights reserved.
+//
+
+import XCTest
+import Freddy
+
+class JSONTransformerTests: XCTestCase {
+
+    let dateTestData = [
+        ("1970-01-01T00:01:01", NSDate(timeIntervalSince1970: 61), JSONDateTransformer.ISO8601.WithoutTimeZone),
+        ("1970-01-01T00:01:02-04:00", NSDate(timeIntervalSince1970: 62 + 3600*4), JSONDateTransformer.ISO8601.WithTimeZone),
+        ("1970-01-01T00:01:01.125-04:00", NSDate(timeIntervalSince1970: 61.125 + 3600*4), JSONDateTransformer.ISO8601.WithTimeZoneAndFractionalSeconds),
+    ]
+
+    func testISO8601DateTransformer() {
+        for (s, expectedDate, format) in dateTestData {
+            let json = JSON.String(s)
+            do {
+                let date = try json.transformed(transformer: JSONDateTransformer(iso8601: format))
+                let diff = date.timeIntervalSinceDate(expectedDate)
+                XCTAssertEqualWithAccuracy(diff, 0, accuracy: 0.01)
+            } catch {
+                XCTFail("Unexpected error \(error)")
+            }
+        }
+    }
+
+    struct MyDateContainer {
+        let date: NSDate
+    }
+
+    struct MyDateContainerTransformer: JSONValueTransformer {
+        func transformValue(value: NSDate) throws -> MyDateContainer {
+            return MyDateContainer(date: value)
+        }
+    }
+
+    func testTransformerChainLink() {
+        let (s, expectedDate, format) = dateTestData[0]
+        let json = JSON.String(s)
+        let transformer = JSONTransformerChainLink(from: JSONDateTransformer(iso8601: format), to: MyDateContainerTransformer())
+        do {
+            let container = try json.transformed(transformer: transformer)
+            let diff = container.date.timeIntervalSinceDate(expectedDate)
+            XCTAssertEqualWithAccuracy(diff, 0, accuracy: 0.01)
+        } catch {
+            XCTFail("Unexpected error \(error)")
+        }
+    }
+
+}


### PR DESCRIPTION
See #118 for some background. This PR is a WIP / proof of concept / starting point for discussion. It’s not very long, so the following assumes you’ve read the changes.
### Pros

This technique essentially gives us a way to write a “state-bearing” JSONDecodable. The particular pain point of parsing ISO8601 dates is directly addressed in this PR. More complex dates (e.g., .NET timestamp things) are easily pluggable into this system too.

The In/Out protocol system also allows more general things like the `JSONTransformerChainLink` in the PR. I currently don’t think this class should be included in Freddy, but putting it out as a proof of what’s possible.
### Cons

The number of functions we have to add to JSONSubscripting is annoying, unless I’m missing a way to collapse them down. The PR adds a single one for `In=String`, but if that’s how we have to do it, there need to be 7-8 functions (one for each JSON type plus `JSON` itself, probably), plus all the “missing key” etc. variants.

It’s not immediately obvious when one should choose JSONDecodable vs JSONValueTransformable - JSONValueTransformable is “more powerful” than JSONDecodable, with the drawback that it requires instantiating an instance of the transformer type. Can we coalesce these into one?
### Alternatives

One alternative I considered is to not have an `In` type in the protocol, and instead provide methods for each of the JSON types:

``` swift
public protocol JSONValueTransformer {
    associatedtype Out

    func transformValue(value: JSON) throws -> Out
    func transformValue(value: [JSON]) throws -> Out
    func transformValue(value: [String : JSON]) throws -> Out
    func transformValue(value: Double) throws -> Out
    func transformValue(value: Int) throws -> Out
    func transformValue(value: String) throws -> Out
    func transformValue(value: Bool) throws -> Out
    func transformNull() throws -> Out
}

extension JSONValueTransformer {
    public func transformValue(value: JSON) throws -> Out {
        switch value {
        case .Array(let arr):       return try transformValue(arr)
        case .Dictionary(let dict): return try transformValue(dict)
        case .String(let string):   return try transformValue(string)
        case .Double(let double):   return try transformValue(double)
        case .Int(let int):         return try transformValue(int)
        case .Bool(let bool):       return try transformValue(bool)
        case .Null:                 return try transformNull()
        }
    }

    public func transformValue(value: [JSON]) throws -> Out          { throw JSONValueTransformerError.InvalidInputType }
    public func transformValue(value: [String : JSON]) throws -> Out { throw JSONValueTransformerError.InvalidInputType }
    public func transformValue(value: Double) throws -> Out          { throw JSONValueTransformerError.InvalidInputType }
    public func transformValue(value: Int) throws -> Out             { throw JSONValueTransformerError.InvalidInputType }
    public func transformValue(value: String) throws -> Out          { throw JSONValueTransformerError.InvalidInputType }
    public func transformValue(value: Bool) throws -> Out            { throw JSONValueTransformerError.InvalidInputType }
    public func transformNull() throws -> Out                        { throw JSONValueTransformerError.InvalidInputType }
}
```

This reduces the API surface we have to add to JSONSubscripting, but seems less nice in every other way.
