### PR TITLE
Swift3: Don’t cast Bool to AnyObject when serializing JSON, instead initialize an NSNumber

### DIFF
--- a/Sources/JSONSerializing.swift
+++ b/Sources/JSONSerializing.swift
@@ -34,7 +34,7 @@ extension JSON {
         case .Int(let int):
             return int as AnyObject
         case .Bool(let b):
-            return b as AnyObject
+            return NSNumber(value: b)
         case .null:
             return NSNull()
         }


### PR DESCRIPTION
See rdar://27922204 (https://openradar.appspot.com/27922204)

This fixed the 2 failing Tests