### PR TITLE
Added Int, Double, Bool conversion to String

### DIFF
--- a/Sources/JSONDecodable.swift
+++ b/Sources/JSONDecodable.swift
@@ -67,10 +67,19 @@ extension String: JSONDecodable {
     ///           an instance of `String` cannot be created from the `JSON` value that was
     ///           passed to this initializer.
     public init(json: JSON) throws {
-        guard case let .String(string) = json else {
+        
+        switch json {
+        case let .String(string):
+            self = string
+        case let .Int(int):
+            self = String(int)
+        case let .Bool(bool):
+            self = String(bool)
+        case let .Double(double):
+            self = String(double)
+        default:
             throw JSON.Error.ValueNotConvertible(value: json, to: Swift.String)
         }
-        self = string
     }
     
 }

--- a/Tests/JSONDecodableTests.swift
+++ b/Tests/JSONDecodableTests.swift
@@ -95,10 +95,28 @@ class JSONDecodableTests: XCTestCase {
         }
         
         do {
-            _ = try String(json: 4)
-            XCTFail("Should not be able to instantiate `String` with `Int` `JSON`.")
+            let four = try String(json: 4)
+            XCTAssertEqual(four, "4", "`four` and `4` should be equal.")
         } catch JSON.Error.ValueNotConvertible(let type) {
-            XCTAssert(true, "\(type) should not be covertible from 'bad' `Int.")
+            XCTAssert(true, "\(type) should be covertible from `Int.")
+        } catch {
+            XCTFail("Failed for unknown reason: \(error).")
+        }
+        
+        do {
+            let twoAndHalf = try String(json: 2.5)
+            XCTAssertEqual(twoAndHalf, "2.5", "`twoAndHalf` and `2.5` should be equal.")
+        } catch JSON.Error.ValueNotConvertible(let type) {
+            XCTAssert(true, "\(type) should be covertible from `Double.")
+        } catch {
+            XCTFail("Failed for unknown reason: \(error).")
+        }
+        
+        do {
+            let positive = try String(json: true)
+            XCTAssertEqual(positive, "true", "`positive` and `true` should be equal.")
+        } catch JSON.Error.ValueNotConvertible(let type) {
+            XCTAssert(true, "\(type) should be covertible from `Bool.")
         } catch {
             XCTFail("Failed for unknown reason: \(error).")
         }

--- a/Tests/JSONParserTests.swift
+++ b/Tests/JSONParserTests.swift
@@ -249,7 +249,6 @@ class JSONParserTests: XCTestCase {
 
         XCTAssertEqual(try? json.int("exceedsIntMax"), nil, "as int")
         XCTAssertEqual(try? json.double("exceedsIntMax"), Double(anyValueExceedingIntMax), "as double")
-        XCTAssertEqual(try? json.string("exceedsIntMax"), nil, "as string")
     }
 
     // This test should also be run on the iPhone 5 simulator to check 32-bit support.


### PR DESCRIPTION
On my opinion conversion from Int, Double, Bool to String can be very useful,
for ex. next situation:
I have Itinerary number something as 3445452345 on 64-bit platform it's Integer, but on 32-bit it will be converted to String (because number is bigger than Int.max). To have two condition it's not convenience and error-prone so I want to force this value to be a String.

Also as a client I want to operate on some values as on Strings not matter is it Int or String actually