### PR TITLE
Allow leading zero with exponents; e.g., "0e1".

### DIFF
--- a/Sources/JSONParser.swift
+++ b/Sources/JSONParser.swift
@@ -659,12 +659,16 @@ private struct NumberParser {
             return
         }
 
-        guard input[loc] == Literal.PERIOD else {
-            state = .Done
-            return
-        }
+        switch input[loc] {
+        case Literal.PERIOD:
+            state = .Decimal
 
-        state = .Decimal
+        case Literal.e, Literal.E:
+            state = .Exponent
+
+        default:
+            state = .Done
+        }
     }
 
     mutating func parsePreDecimalDigits(@noescape f: (UInt8) throws -> Void) rethrows {

--- a/Tests/JSONParserTests.swift
+++ b/Tests/JSONParserTests.swift
@@ -158,6 +158,10 @@ class JSONParserTests: XCTestCase {
             ("  0  ", 0),
             ("123", 123),
             ("  -20  ", -20),
+            ("-0", 0),
+            ("0e1", 0),
+            ("-0e20", 0),
+            ("0.1e1", 1),
         ] {
             do {
                 let value = try JSONFromString(string).int()
@@ -197,10 +201,10 @@ class JSONParserTests: XCTestCase {
             ("1.0e",  JSONParser.Error.EndOfStreamUnexpected),
             ("1.0e+", JSONParser.Error.EndOfStreamUnexpected),
             ("1.0e-", JSONParser.Error.EndOfStreamUnexpected),
-            ("0e1",   JSONParser.Error.EndOfStreamGarbage(offset: 1)),
         ] {
             do {
-                _ = try JSONFromString(string)
+                let value = try JSONFromString(string)
+                XCTFail("Unexpectedly parsed \(string) as \(value)")
             } catch let error as JSONParser.Error {
                 XCTAssert(error == expectedError)
             } catch {

--- a/Tests/JSONParserTests.swift
+++ b/Tests/JSONParserTests.swift
@@ -172,9 +172,12 @@ class JSONParserTests: XCTestCase {
             ("123", 123),
             ("  -20  ", -20),
             ("-0", 0),
+            ("0e0", 0),
+            ("0e1", 0),
             ("0e1", 0),
             ("-0e20", 0),
             ("0.1e1", 1),
+            ("0.1E1", 1),
         ] {
             do {
                 let value = try JSONFromString(string).int()
@@ -194,6 +197,8 @@ class JSONParserTests: XCTestCase {
             ("123.45E2", 123.45E2),
             ("123.45e+2", 123.45e+2),
             ("-123.45e-2", -123.45e-2),
+            ("0.1e-1", 0.01),
+            ("-0.1E-1", -0.01),
         ] {
             do {
                 let value = try JSONFromString(string).double()

--- a/Tests/JSONParserTests.swift
+++ b/Tests/JSONParserTests.swift
@@ -178,6 +178,8 @@ class JSONParserTests: XCTestCase {
             ("-0e20", 0),
             ("0.1e1", 1),
             ("0.1E1", 1),
+            ("0e01", 0),
+            ("0.1e0001", 1),
         ] {
             do {
                 let value = try JSONFromString(string).int()


### PR DESCRIPTION
Fixes one of the two issues brought up in #198.