### PR TITLE
Specify swift version for the Pod framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,18 @@ osx_image: xcode8
 install:
 - gem install xcpretty --no-rdoc --no-ri --no-document
 - gem install jazzy --no-rdoc --no-ri --no-document
-- brew install carthage --force-bottle
+- brew outdated carthage || brew upgrade carthage
 script:
 - open -b com.apple.iphonesimulator # Travis CI workaround
 - set -o pipefail && xcodebuild test -scheme 'Freddy' -sdk macosx | xcpretty -c
 - set -o pipefail && xcodebuild test -scheme 'MobileFreddy' -sdk iphonesimulator -destination
   'platform=iOS Simulator,name=iPhone 5' | xcpretty -c
+- open -b com.apple.appletvsimulator # Travis CI workaround
 - set -o pipefail && xcodebuild test -scheme 'TVFreddy' -sdk appletvsimulator -destination
   'platform=tvOS Simulator,name=Apple TV 1080p' | xcpretty -c
 - carthage build --no-skip-current
 - pod lib lint --quick
 after_success:
-- sleep 5
 - "./Configurations/publish_docs.sh"
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ script:
 - carthage build --no-skip-current
 - pod lib lint --quick
 after_success:
+- sleep 5
 - "./Configurations/publish_docs.sh"
 notifications:
   slack:

--- a/Freddy.podspec
+++ b/Freddy.podspec
@@ -28,5 +28,5 @@ Pod::Spec.new do |s|
   s.source_files  = "Sources/**/*.{h,swift}"
 
   s.requires_arc = true
-
+  s.pod_target_xcconfig = { 'SWIFT_VERSION' => '3.0' }
 end

--- a/Freddy.xcodeproj/project.pbxproj
+++ b/Freddy.xcodeproj/project.pbxproj
@@ -70,6 +70,12 @@
 		DB6ADFC71C23631500D77BF1 /* sampleNoWhiteSpace.JSON in Resources */ = {isa = PBXBuildFile; fileRef = DB6ADFC21C23631500D77BF1 /* sampleNoWhiteSpace.JSON */; };
 		DB6ADFC81C23631500D77BF1 /* sampleNoWhiteSpace.JSON in Resources */ = {isa = PBXBuildFile; fileRef = DB6ADFC21C23631500D77BF1 /* sampleNoWhiteSpace.JSON */; };
 		DC194EB91C47D87B001D4569 /* JSONTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC194EB81C47D87B001D4569 /* JSONTests.swift */; };
+		DC5F54FB1D82E79400670855 /* JSONTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC194EB81C47D87B001D4569 /* JSONTests.swift */; };
+		DC5F54FC1D82E79500670855 /* JSONTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC194EB81C47D87B001D4569 /* JSONTests.swift */; };
+		DC5F54FD1D82E79900670855 /* JSONEncodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C67C72A1C3B32A6003D5A05 /* JSONEncodableTests.swift */; };
+		DC5F54FE1D82E79A00670855 /* JSONEncodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C67C72A1C3B32A6003D5A05 /* JSONEncodableTests.swift */; };
+		DC5F54FF1D82E79F00670855 /* JSONSubscriptingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C7BD51E1C7A4B9300A6ED4B /* JSONSubscriptingTests.swift */; };
+		DC5F55001D82E7A000670855 /* JSONSubscriptingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C7BD51E1C7A4B9300A6ED4B /* JSONSubscriptingTests.swift */; };
 		E43B67DB1C59598700ACE390 /* JSONEncodingDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43B67DA1C59598700ACE390 /* JSONEncodingDetector.swift */; };
 		E43B67DC1C59598700ACE390 /* JSONEncodingDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43B67DA1C59598700ACE390 /* JSONEncodingDetector.swift */; };
 		E43B67DD1C59598700ACE390 /* JSONEncodingDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43B67DA1C59598700ACE390 /* JSONEncodingDetector.swift */; };
@@ -587,8 +593,11 @@
 				DB6ADFB51C2362FF00D77BF1 /* JSONParserTests.swift in Sources */,
 				E43B67E11C5962CD00ACE390 /* JSONEncodingDetectorTests.swift in Sources */,
 				3F70EA991C6D0EC500972CEB /* JSONSerializingTests.swift in Sources */,
+				DC5F54FF1D82E79F00670855 /* JSONSubscriptingTests.swift in Sources */,
 				DB6ADFBB1C2362FF00D77BF1 /* JSONTypeTests.swift in Sources */,
+				DC5F54FD1D82E79900670855 /* JSONEncodableTests.swift in Sources */,
 				DB6ADFB21C2362FF00D77BF1 /* JSONDecodableTests.swift in Sources */,
+				DC5F54FB1D82E79400670855 /* JSONTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -648,8 +657,11 @@
 				DB6ADFB61C2362FF00D77BF1 /* JSONParserTests.swift in Sources */,
 				E43B67E21C5962CD00ACE390 /* JSONEncodingDetectorTests.swift in Sources */,
 				3F70EA9A1C6D0EC500972CEB /* JSONSerializingTests.swift in Sources */,
+				DC5F55001D82E7A000670855 /* JSONSubscriptingTests.swift in Sources */,
 				DB6ADFBC1C2362FF00D77BF1 /* JSONTypeTests.swift in Sources */,
+				DC5F54FE1D82E79A00670855 /* JSONEncodableTests.swift in Sources */,
 				DB6ADFB31C2362FF00D77BF1 /* JSONDecodableTests.swift in Sources */,
+				DC5F54FC1D82E79500670855 /* JSONTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/JSON.swift
+++ b/Sources/JSON.swift
@@ -9,17 +9,17 @@
 /// An enum to describe the structure of JSON.
 public enum JSON {
     /// A case for denoting an array with an associated value of `[JSON]`
-    case Array([JSON])
+    case array([JSON])
     /// A case for denoting a dictionary with an associated value of `[Swift.String: JSON]`
-    case Dictionary([Swift.String: JSON])
+    case dictionary([String: JSON])
     /// A case for denoting a double with an associated value of `Swift.Double`.
-    case Double(Swift.Double)
+    case double(Double)
     /// A case for denoting an integer with an associated value of `Swift.Int`.
-    case Int(Swift.Int)
+    case int(Int)
     /// A case for denoting a string with an associated value of `Swift.String`.
-    case String(Swift.String)
+    case string(String)
     /// A case for denoting a boolean with an associated value of `Swift.Bool`.
-    case Bool(Swift.Bool)
+    case bool(Bool)
     /// A case for denoting null.
     case null
 }
@@ -31,10 +31,10 @@ extension JSON {
     /// An enum to encapsulate errors that may arise in working with `JSON`.
     public enum Error: Swift.Error {
         /// The `index` is out of bounds for a JSON array
-        case indexOutOfBounds(index: Swift.Int)
+        case indexOutOfBounds(index: Int)
         
         /// The `key` was not found in the JSON dictionary
-        case keyNotFound(key: Swift.String)
+        case keyNotFound(key: String)
         
         /// The JSON is not subscriptable with `type`
         case unexpectedSubscript(type: JSONPathType.Type)
@@ -50,21 +50,21 @@ extension JSON {
 /// Return `true` if `lhs` is equal to `rhs`.
 public func ==(lhs: JSON, rhs: JSON) -> Bool {
     switch (lhs, rhs) {
-    case (.Array(let arrL), .Array(let arrR)):
+    case (.array(let arrL), .array(let arrR)):
         return arrL == arrR
-    case (.Dictionary(let dictL), .Dictionary(let dictR)):
+    case (.dictionary(let dictL), .dictionary(let dictR)):
         return dictL == dictR
-    case (.String(let strL), .String(let strR)):
+    case (.string(let strL), .string(let strR)):
         return strL == strR
-    case (.Double(let dubL), .Double(let dubR)):
+    case (.double(let dubL), .double(let dubR)):
         return dubL == dubR
-    case (.Double(let dubL), .Int(let intR)):
+    case (.double(let dubL), .int(let intR)):
         return dubL == Double(intR)
-    case (.Int(let intL), .Int(let intR)):
+    case (.int(let intL), .int(let intR)):
         return intL == intR
-    case (.Int(let intL), .Double(let dubR)):
+    case (.int(let intL), .double(let dubR)):
         return Double(intL) == dubR
-    case (.Bool(let bL), .Bool(let bR)):
+    case (.bool(let bL), .bool(let bR)):
         return bL == bR
     case (.null, .null):
         return true
@@ -82,12 +82,12 @@ extension JSON: CustomStringConvertible {
     /// A textual representation of `self`.
     public var description: Swift.String {
         switch self {
-        case .Array(let arr):       return Swift.String(describing: arr)
-        case .Dictionary(let dict): return Swift.String(describing: dict)
-        case .String(let string):   return string
-        case .Double(let double):   return Swift.String(describing: double)
-        case .Int(let int):         return Swift.String(describing: int)
-        case .Bool(let bool):       return Swift.String(describing: bool)
+        case .array(let arr):       return String(describing: arr)
+        case .dictionary(let dict): return String(describing: dict)
+        case .string(let string):   return string
+        case .double(let double):   return String(describing: double)
+        case .int(let int):         return String(describing: int)
+        case .bool(let bool):       return String(describing: bool)
         case .null:                 return "null"
         }
     }

--- a/Sources/JSONDecodable.swift
+++ b/Sources/JSONDecodable.swift
@@ -28,12 +28,12 @@ extension Double: JSONDecodable {
     ///           passed to this initializer.
     public init(json: JSON) throws {
         switch json {
-        case let .Double(double):
+        case let .double(double):
             self = double
-        case let .Int(int):
-            self = Swift.Double(int)
+        case let .int(int):
+            self = Double(int)
         default:
-            throw JSON.Error.valueNotConvertible(value: json, to: Swift.Double)
+            throw JSON.Error.valueNotConvertible(value: json, to: Double.self)
         }
     }
     
@@ -48,12 +48,12 @@ extension Int: JSONDecodable {
     ///           passed to this initializer.
     public init(json: JSON) throws {
         switch json {
-        case let .Double(double) where double <= Double(Swift.Int.max):
-            self = Swift.Int(double)
-        case let .Int(int):
+        case let .double(double) where double <= Double(Int.max):
+            self = Int(double)
+        case let .int(int):
             self = int
         default:
-            throw JSON.Error.valueNotConvertible(value: json, to: Swift.Int)
+            throw JSON.Error.valueNotConvertible(value: json, to: Int.self)
         }
     }
     
@@ -68,16 +68,16 @@ extension String: JSONDecodable {
     ///           passed to this initializer.
     public init(json: JSON) throws {
         switch json {
-        case let .String(string):
+        case let .string(string):
             self = string
-        case let .Int(int):
+        case let .int(int):
             self = String(int)
-        case let .Bool(bool):
+        case let .bool(bool):
             self = String(bool)
-        case let .Double(double):
+        case let .double(double):
             self = String(double)
         default:
-            throw JSON.Error.valueNotConvertible(value: json, to: Swift.String)
+            throw JSON.Error.valueNotConvertible(value: json, to: String.self)
         }
     }
     
@@ -91,8 +91,8 @@ extension Bool: JSONDecodable {
     ///           an instance of `Bool` cannot be created from the `JSON` value that was
     ///           passed to this initializer.
     public init(json: JSON) throws {
-        guard case let .Bool(bool) = json else {
-            throw JSON.Error.valueNotConvertible(value: json, to: Swift.Bool)
+        guard case let .bool(bool) = json else {
+            throw JSON.Error.valueNotConvertible(value: json, to: Bool.self)
         }
         self = bool
     }
@@ -122,9 +122,9 @@ internal extension JSON {
     /// - returns: An `Array` of `JSON` elements
     /// - throws: Any of the `JSON.Error` cases thrown by `decode(type:)`.
     /// - seealso: `JSON.decode(_:type:)`
-    static func getArray(_ json: JSON) throws -> [JSON] {
+    static func getArray(from json: JSON) throws -> [JSON] {
         // Ideally should be expressed as a conditional protocol implementation on Swift.Array.
-        guard case let .Array(array) = json else {
+        guard case let .array(array) = json else {
             throw Error.valueNotConvertible(value: json, to: Swift.Array<JSON>)
         }
         return array
@@ -135,38 +135,39 @@ internal extension JSON {
     /// - returns: An `Dictionary` of `String` mapping to `JSON` elements
     /// - throws: Any of the `JSON.Error` cases thrown by `decode(type:)`.
     /// - seealso: `JSON.decode(_:type:)`
-    static func getDictionary(_ json: JSON) throws -> [Swift.String: JSON] {
+    static func getDictionary(from json: JSON) throws -> [String: JSON] {
         // Ideally should be expressed as a conditional protocol implementation on Swift.Dictionary.
-        guard case let .Dictionary(dictionary) = json else {
-            throw Error.valueNotConvertible(value: json, to: Swift.Dictionary<Swift.String, JSON>)
+        guard case let .dictionary(dictionary) = json else {
+            throw Error.valueNotConvertible(value: json, to: Swift.Dictionary<String, JSON>)
         }
         return dictionary
     }
     
     /// Attempts to decode many values from a descendant JSON array at a path
     /// into JSON.
-    /// - parameter: A `JSON` to be used to create the returned `Array` of some type conforming to `JSONDecodable`.
+    /// - parameter json: A `JSON` to be used to create the returned `Array` of some type conforming to `JSONDecodable`.
     /// - returns: An `Array` of `Decoded` elements.
     /// - throws: Any of the `JSON.Error` cases thrown by `decode(type:)`, as
     ///   well as any error that arises from decoding the contained values.
     /// - seealso: `JSON.decode(_:type:)`
-    static func getArrayOf<Decoded: JSONDecodable>(_ json: JSON) throws -> [Decoded] {
+    static func decodedArray<Decoded: JSONDecodable>(from json: JSON) throws -> [Decoded] {
         // Ideally should be expressed as a conditional protocol implementation on Swift.Dictionary.
         // This implementation also doesn't do the `type = Type.self` trick.
-        return try getArray(json).map(Decoded.init)
+        return try getArray(from: json).map(Decoded.init)
     }
     
     /// Attempts to decode many values from a descendant JSON object at a path
     /// into JSON.
+    /// - parameter json: A `JSON` to be used to create the returned `Dictionary` of some type conforming to `JSONDecodable`.
     /// - returns: A `Dictionary` of string keys and `Decoded` values.
     /// - throws: One of the `JSON.Error` cases thrown by `decode(_:type:)` or
     ///           any error that arises from decoding the contained values.
     /// - seealso: `JSON.decode(_:type:)`
-    static func getDictionaryOf<Decoded: JSONDecodable>(_ json: JSON) throws -> [Swift.String: Decoded] {
-        guard case let .Dictionary(dictionary) = json else {
-            throw Error.valueNotConvertible(value: json, to: Swift.Dictionary<Swift.String, Decoded>)
+    static func decodedDictionary<Decoded: JSONDecodable>(from json: JSON) throws -> [Swift.String: Decoded] {
+        guard case let .dictionary(dictionary) = json else {
+            throw Error.valueNotConvertible(value: json, to: Swift.Dictionary<String, Decoded>)
         }
-        var decodedDictionary = Swift.Dictionary<Swift.String, Decoded>(minimumCapacity: dictionary.count)
+        var decodedDictionary = Swift.Dictionary<String, Decoded>(minimumCapacity: dictionary.count)
         for (key, value) in dictionary {
             decodedDictionary[key] = try Decoded(json: value)
         }

--- a/Sources/JSONEncodable.swift
+++ b/Sources/JSONEncodable.swift
@@ -13,23 +13,23 @@ public protocol JSONEncodable {
     /// Converts an instance of a conforming type to `JSON`.
     /// - returns: An instance of `JSON`.
     /// - Note: If conforming to `JSONEncodable` with a custom type of your own, you should return an instance of 
-    /// `JSON.Dictionary`.
+    /// `JSON.dictionary`.
     func toJSON() -> JSON
 }
 
 extension Array where Element: JSONEncodable {
     /// Converts an instance of `Array` whose elements conform to `JSONEncodable` to `JSON`.
-    /// - returns: An instance of `JSON` where the enum case is `.Array`.
+    /// - returns: An instance of `JSON` where the enum case is `.array`.
     public func toJSON() -> JSON {
         let arrayOfJSON = self.map { $0.toJSON() }
-        return .Array(arrayOfJSON)
+        return .array(arrayOfJSON)
     }
 }
 
 extension Dictionary where Value: JSONEncodable {
     /// Converts an instance of `Dictionary` whose values conform to `JSONEncodable` to `JSON`.  The keys in the resulting
-    /// `JSON.Dictionary` will be of type `String`.
-    /// - returns: An instance of `JSON` where the enum case is `.Dictionary`.
+    /// `JSON.dictionary` will be of type `String`.
+    /// - returns: An instance of `JSON` where the enum case is `.dictionary`.
     public func toJSON() -> JSON {
         var jsonDictionary = [String: JSON]()
         
@@ -38,39 +38,39 @@ extension Dictionary where Value: JSONEncodable {
             jsonDictionary[key] = v.toJSON()
         }
         
-        return .Dictionary(jsonDictionary)
+        return .dictionary(jsonDictionary)
     }
 }
 
 extension Int: JSONEncodable {
     /// Converts an instance of a conforming type to `JSON`.
-    /// - returns: An instance of `JSON` where the enum case is `.Int`.
+    /// - returns: An instance of `JSON` where the enum case is `.int`.
     public func toJSON() -> JSON {
-        return .Int(self)
+        return .int(self)
     }
 }
 
 extension Double: JSONEncodable {
     /// Converts an instance of a conforming type to `JSON`.
-    /// - returns: An instance of `JSON` where the enum case is `.Double`.
+    /// - returns: An instance of `JSON` where the enum case is `.double`.
     public func toJSON() -> JSON {
-        return .Double(self)
+        return .double(self)
     }
 }
 
 extension String: JSONEncodable {
     /// Converts an instance of a conforming type to `JSON`.
-    /// - returns: An instance of `JSON` where the enum case is `.String`.
+    /// - returns: An instance of `JSON` where the enum case is `.string`.
     public func toJSON() -> JSON {
-        return .String(self)
+        return .string(self)
     }
 }
 
 extension Bool: JSONEncodable {
     /// Converts an instance of a conforming type to `JSON`.
-    /// - returns: An instance of `JSON` where the enum case is `.Bool`.
+    /// - returns: An instance of `JSON` where the enum case is `.bool`.
     public func toJSON() -> JSON {
-        return .Bool(self)
+        return .bool(self)
     }
 }
 

--- a/Sources/JSONLiteralConvertible.swift
+++ b/Sources/JSONLiteralConvertible.swift
@@ -13,7 +13,7 @@ extension JSON: ExpressibleByArrayLiteral {
     /// Create an instance by copying each element of the `collection` into a
     /// new `Array`.
     public init<Collection: Swift.Collection>(_ collection: Collection) where Collection.Iterator.Element == JSON {
-        self = .Array(Swift.Array(collection))
+        self = .array(Swift.Array(collection))
     }
 
     /// Create an instance initialized with `elements`.
@@ -44,7 +44,7 @@ extension JSON: ExpressibleByDictionaryLiteral {
 
     /// Create an instance initialized to `dictionary`.
     public init(_ dictionary: Swift.Dictionary<Swift.String, JSON>) {
-        self = .Dictionary(dictionary)
+        self = .dictionary(dictionary)
     }
 }
 
@@ -54,7 +54,7 @@ extension JSON: ExpressibleByFloatLiteral {
     
     /// Create an instance initialized to `Double` `value`.
     public init(_ value: Swift.Double) {
-        self = .Double(value)
+        self = .double(value)
     }
     
     /// Create a literal instance initialized to `value`.
@@ -70,7 +70,7 @@ extension JSON: ExpressibleByIntegerLiteral {
     
     /// Create an instance initialized to `Int` by `value`.
     public init(_ value: Swift.Int) {
-        self = .Int(value)
+        self = .int(value)
     }
     
     /// Create a literal instance initialized to `value`.
@@ -86,7 +86,7 @@ extension JSON: ExpressibleByStringLiteral {
     
     /// Create an instance initialized to `String` by `text`.
     public init(_ text: Swift.String) {
-        self = .String(text)
+        self = .string(text)
     }
 
     /// Create a literal instance initialized to `value`.
@@ -112,7 +112,7 @@ extension JSON: ExpressibleByBooleanLiteral {
 
     /// Create an instance initialized to `Bool` by `value`.
     public init(_ value: Swift.Bool) {
-        self = .Bool(value)
+        self = .bool(value)
     }
 
     /// Create a literal instance initialized to `value`.

--- a/Sources/JSONParser.swift
+++ b/Sources/JSONParser.swift
@@ -153,7 +153,7 @@ public struct JSONParser {
                     break advancing
                 }
             } catch let InternalError.numberOverflow(offset: start) {
-                return try decodeNumberAsString(start)
+                return try decodeNumberAsString(from: start)
             }
         }
         
@@ -165,7 +165,6 @@ public struct JSONParser {
             switch input[loc] {
             case Literal.SPACE, Literal.TAB, Literal.RETURN, Literal.NEWLINE:
                 loc = (loc + 1)
-
             default:
                 return
             }
@@ -208,7 +207,7 @@ public struct JSONParser {
         }
 
         loc += 4
-        return .Bool(true)
+        return .bool(true)
     }
 
     private mutating func decodeFalse() throws -> JSON {
@@ -224,7 +223,7 @@ public struct JSONParser {
         }
 
         loc += 5
-        return .Bool(false)
+        return .bool(false)
     }
 
     private var stringDecodingBuffer = [UInt8]()
@@ -265,7 +264,7 @@ public struct JSONParser {
                     String(cString: UnsafePointer($0.baseAddress!))
                 }
                 
-                return .String(string)
+                return .string(string)
 
             case let other:
                 stringDecodingBuffer.append(other)
@@ -348,7 +347,7 @@ public struct JSONParser {
 
             if loc < input.count && input[loc] == Literal.RIGHT_BRACKET {
                 loc = (loc + 1)
-                return .Array(items)
+                return .array(items)
             }
 
             if !items.isEmpty {
@@ -405,7 +404,7 @@ public struct JSONParser {
                     obj[k] = v
                 }
                 decodeObjectBuffers.putBuffer(pairs)
-                return .Dictionary(obj)
+                return .dictionary(obj)
             }
 
             if !pairs.isEmpty {
@@ -421,7 +420,7 @@ public struct JSONParser {
                 throw Error.dictionaryMissingKey(offset: start)
             }
 
-            let key = try decodeString().string()
+            let key = try decodeString().getString()
             skipWhitespace()
 
             guard loc < input.count && input[loc] == Literal.COLON else {
@@ -482,7 +481,7 @@ public struct JSONParser {
         }
 
         loc = parser.loc
-        return .Int(signedValue)
+        return .int(signedValue)
     }
 
     private mutating func decodeFloatingPointValue(_ parser: NumberParser, sign: Sign, value: Double) throws -> JSON {
@@ -525,20 +524,21 @@ public struct JSONParser {
         }
 
         loc = parser.loc
-        return .Double(Double(sign.rawValue) * value * pow(10, Double(exponentSign.rawValue) * exponent))
+        return .double(Double(sign.rawValue) * value * pow(10, Double(exponentSign.rawValue) * exponent))
     }
 
-    private mutating func decodeNumberAsString(_ start: Int) throws -> JSON {
+
+    private mutating func decodeNumberAsString(from position: Int) throws -> JSON {
         var parser: NumberParser = {
             let state: NumberParser.State
-            switch input[start] {
+            switch input[position] {
             case Literal.MINUS: state = .leadingMinus
             case Literal.zero: state = .leadingZero
             case Literal.one...Literal.nine: state = .preDecimalDigits
             default:
                 fatalError("Internal error: decodeNumber called on not-a-number")
             }
-            return NumberParser(loc: start, input: input, state: state)
+            return NumberParser(loc: position, input: input, state: state)
         }()
 
         stringDecodingBuffer.removeAll(keepingCapacity: true)
@@ -581,7 +581,7 @@ public struct JSONParser {
                 }
 
                 loc = parser.loc
-                return .String(string)
+                return .string(string)
             }
         }
     }
@@ -785,7 +785,7 @@ private struct NumberParser {
 
 public extension JSONParser {
 
-    /// Creates a `JSONParser` ready to parse UTF-8 encoded `NSData`.
+    /// Creates a `JSONParser` ready to parse UTF-8 encoded `Data`.
     ///
     /// If the data is mutable, it is copied before parsing. The data's lifetime
     /// is extended for the duration of parsing.
@@ -827,8 +827,8 @@ public extension JSONParser {
 
 extension JSONParser: JSONParserType {
 
-    /// Creates an instance of `JSON` from UTF-8 encoded `NSData`.
-    /// - parameter data: An instance of `NSData` to parse `JSON` from.
+    /// Creates an instance of `JSON` from UTF-8 encoded `Data`.
+    /// - parameter data: An instance of `Data` to parse `JSON` from.
     /// - throws: Any `JSONParser.Error` that arises during decoding.
     /// - seealso: JSONParser.parse()
     public static func createJSONFromData(_ data: Data) throws -> JSON {

--- a/Sources/JSONParsing.swift
+++ b/Sources/JSONParsing.swift
@@ -10,11 +10,11 @@ import Foundation
 
 // MARK: - Deserialize JSON
 
-/// Protocol describing a backend parser that can produce `JSON` from `NSData`.
+/// Protocol describing a backend parser that can produce `JSON` from `Data`.
 public protocol JSONParserType {
 
-    /// Creates an instance of `JSON` from `NSData`.
-    /// - parameter data: An instance of `NSData` to use to create `JSON`.
+    /// Creates an instance of `JSON` from `Data`.
+    /// - parameter data: An instance of `Data` to use to create `JSON`.
     /// - throws: An error that may arise from calling `JSONObjectWithData(_:options:)` on `NSJSONSerialization` with the given data.
     /// - returns: An instance of `JSON`.
     static func createJSONFromData(_ data: Data) throws -> JSON
@@ -39,12 +39,12 @@ extension JSON {
 
 extension JSONSerialization: JSONParserType {
 
-    // MARK: Decode NSData
+    // MARK: Decode Data
 
     /// Use the built-in, Objective-C based JSON parser to create `JSON`.
-    /// - parameter data: An instance of `NSData`.
+    /// - parameter data: An instance of `Data`.
     /// - returns: An instance of `JSON`.
-    /// - throws: An error that may arise if the `NSData` cannot be parsed into an object.
+    /// - throws: An error that may arise if the `Data` cannot be parsed into an object.
     public static func createJSONFromData(_ data: Data) throws -> JSON {
         return makeJSON(try JSONSerialization.jsonObject(with: data, options: []))
     }
@@ -60,10 +60,10 @@ extension JSONSerialization: JSONParserType {
             let numberType = CFNumberGetType(n)
             switch numberType {
             case .charType:
-                return .Bool(n.boolValue)
+                return .bool(n.boolValue)
 
             case .shortType, .intType, .longType, .cfIndexType, .nsIntegerType, .sInt8Type, .sInt16Type, .sInt32Type:
-                return .Int(n.intValue)
+                return .int(n.intValue)
 
             case .sInt64Type, .longLongType /* overflows 32-bit Int */:
                 #if /* 32-bit arch */ arch(arm) || arch(i386)
@@ -80,13 +80,13 @@ extension JSONSerialization: JSONParserType {
                     // you'll have to switch from .double to .string for pulling out
                     // overflowing values, but if you stick with a single parser,
                     // you at least won't have architecture-dependent lookups!
-                    return .Double(n.doubleValue)
+                    return .double(n.doubleValue)
                 #else
-                    return .Int(n.intValue)
+                    return .int(n.intValue)
                 #endif
 
             case .float32Type, .float64Type, .floatType, .doubleType, .cgFloatType:
-                return .Double(n.doubleValue)
+                return .double(n.doubleValue)
             }
 
         case let arr as [Any]:
@@ -96,7 +96,7 @@ extension JSONSerialization: JSONParserType {
             return makeJSONDictionary(dict)
 
         case let s as Swift.String:
-            return .String(s)
+            return .string(s)
 
         default:
             return .null
@@ -109,7 +109,7 @@ extension JSONSerialization: JSONParserType {
     /// - parameter jsonArray: The array to transform into a `JSON`.
     /// - returns: An instance of `JSON` matching the array.
     private static func makeJSONArray(_ jsonArray: [Any]) -> JSON {
-        return .Array(jsonArray.map(makeJSON))
+        return .array(jsonArray.map(makeJSON))
     }
 
     // MARK: Make a JSON Dictionary

--- a/Sources/JSONSerializing.swift
+++ b/Sources/JSONSerializing.swift
@@ -6,7 +6,7 @@ import Foundation
 
 extension JSON {
 
-    /// Attempt to serialize `JSON` into an `NSData`.
+    /// Attempt to serialize `JSON` into an `Data`.
     /// - returns: A byte-stream containing the `JSON` ready for wire transfer.
     /// - throws: Errors that arise from `NSJSONSerialization`.
     /// - see: Foundation.NSJSONSerialization
@@ -18,21 +18,21 @@ extension JSON {
     /// - returns: An `Any` suitable for `NSJSONSerialization`'s use.
     private func toNSJSONSerializationValue() -> Any {
         switch self {
-        case .Array(let jsonArray):
+        case .array(let jsonArray):
             return jsonArray.map { $0.toNSJSONSerializationValue() }
-        case .Dictionary(let jsonDictionary):
+        case .dictionary(let jsonDictionary):
             var cocoaDictionary = Swift.Dictionary<Swift.String, Any>(minimumCapacity: jsonDictionary.count)
             for (key, json) in jsonDictionary {
                 cocoaDictionary[key] = json.toNSJSONSerializationValue()
             }
             return cocoaDictionary
-        case .String(let str):
+        case .string(let str):
             return str
-        case .Double(let num):
+        case .double(let num):
             return NSNumber(value: num)
-        case .Int(let int):
+        case .int(let int):
             return NSNumber(value: int)
-        case .Bool(let b):
+        case .bool(let b):
             return NSNumber(value: b)
         case .null:
             return NSNull()

--- a/Tests/JSONDecodableTests.swift
+++ b/Tests/JSONDecodableTests.swift
@@ -146,7 +146,7 @@ class JSONDecodableTests: XCTestCase {
     func testThatJSONBoolIsDecodable() {
         let JSONTrue: JSON = true
         do {
-            let decodedTrue = try JSONTrue.bool()
+            let decodedTrue = try JSONTrue.getBool()
             XCTAssertTrue(decodedTrue, "`JSONTrue` should decode to `true`.")
         } catch {
             XCTFail("`JSONTrue` should decode to `true`.")
@@ -157,7 +157,7 @@ class JSONDecodableTests: XCTestCase {
         let JSONArray: JSON = [1,2,3,4]
         
         do {
-            let decodedArray = try JSONArray.array()
+            let decodedArray = try JSONArray.getArray()
             XCTAssertEqual(decodedArray, [1,2,3,4], "`decodedArray` should match.")
         } catch {
             XCTFail("`decodedArray should be [1,2,3,4]")
@@ -165,7 +165,7 @@ class JSONDecodableTests: XCTestCase {
         
         let badJSONArray: JSON = "bad"
         do {
-            _ = try badJSONArray.array()
+            _ = try badJSONArray.getArray()
             XCTFail("array should not exist.")
         } catch JSON.Error.valueNotConvertible(let type) {
             XCTAssert(true, "\(type) should not be convertible to `[JSON]`")
@@ -178,7 +178,7 @@ class JSONDecodableTests: XCTestCase {
         let JSONDictionary: JSON = ["Matt": 32]
         
         do {
-            let decodedJSONDictionary = try JSONDictionary.dictionary()
+            let decodedJSONDictionary = try JSONDictionary.getDictionary()
             XCTAssertEqual(decodedJSONDictionary, ["Matt": 32], "`decodedJSONDictionary` should equal `[Matt: 32]`.")
         } catch {
             XCTFail("`decodedJSONDictionary` should equal `[Matt: 32]`.")
@@ -186,7 +186,7 @@ class JSONDecodableTests: XCTestCase {
         
         let badJSONDictionary: JSON = 4
         do {
-            _ = try badJSONDictionary.dictionary()
+            _ = try badJSONDictionary.getDictionary()
             XCTFail("There should be no dictionary.")
         } catch JSON.Error.valueNotConvertible(let type) {
             XCTAssertTrue(true, "\(type) shold not be convertible to `[String: JSON]`.")
@@ -199,7 +199,7 @@ class JSONDecodableTests: XCTestCase {
         let oneTwoThreeJSON: JSON = [1,2,3]
         
         do {
-            let decodedOneTwoThree = try oneTwoThreeJSON.arrayOf(type: Swift.Int)
+            let decodedOneTwoThree = try oneTwoThreeJSON.decodedArray(type: Swift.Int)
             XCTAssertEqual(decodedOneTwoThree, [1,2,3], "`decodedOneTwoThree` should be equal to `[1,2,3]`.")
         } catch {
             XCTFail("`decodedOneTwoThree` should be equal to `[1,2,3]`.")
@@ -210,7 +210,7 @@ class JSONDecodableTests: XCTestCase {
         let oneTwoThreeJSON: JSON = ["one": 1, "two": 2, "three": 3]
         
         do {
-            let decodedOneTwoThree = try oneTwoThreeJSON.dictionaryOf(type: Swift.Int)
+            let decodedOneTwoThree = try oneTwoThreeJSON.decodedDictionary(type: Swift.Int)
             XCTAssertEqual(decodedOneTwoThree, ["one": 1, "two": 2, "three": 3], "`decodedOneTwoThree` should be equal to `[\"one\": 1, \"two\": 2, \"three\": 3]`.")
         } catch {
             XCTFail("`decodedOneTwoThree` should be equal to `[\"one\": 1, \"two\": 2, \"three\": 3]`.")
@@ -221,7 +221,7 @@ class JSONDecodableTests: XCTestCase {
         let JSONDictionary: JSON = ["key": .null]
         
         do {
-            let value: Int? = try JSONDictionary.int("key", alongPath: .NullBecomesNil)
+            let value: Int? = try JSONDictionary.getInt(at: "key", alongPath: .NullBecomesNil)
             XCTAssertEqual(value, nil)
         } catch {
             XCTFail("Should have retrieved nil for key `key` in `JSONDictionary` when specifying `ifNull` to be `true`.")
@@ -232,7 +232,7 @@ class JSONDecodableTests: XCTestCase {
         let JSONDictionary: JSON = ["key": .null]
         
         do {
-            let _: Int? = try JSONDictionary.int("key")
+            let _: Int? = try JSONDictionary.getInt(at: "key")
             XCTFail("Should have thrown an error when attempting to retrieve a value for key `key` in `JSONDictionary` when not specifying `ifNull` to be `true`.")
         } catch let JSON.Error.valueNotConvertible(_, to) where to == Int.self {
             return

--- a/Tests/JSONEncodableTests.swift
+++ b/Tests/JSONEncodableTests.swift
@@ -13,7 +13,7 @@ class JSONEncodableTests: XCTestCase {
 
     func testThatJSONEncodableEncodesString() {
         let matt = "Matt"
-        let comparisonMatt = JSON.String(matt)
+        let comparisonMatt = JSON.string(matt)
         let testMatt = matt.toJSON()
         XCTAssertTrue(comparisonMatt == testMatt, "These should be the same!")
     }
@@ -27,14 +27,14 @@ class JSONEncodableTests: XCTestCase {
     
     func testThatJSONEncodableEncodesInt() {
         let thirtyTwo = 32
-        let comparisonThirtyTwo = JSON.Int(thirtyTwo)
+        let comparisonThirtyTwo = JSON.int(thirtyTwo)
         let testThirtyTwo = thirtyTwo.toJSON()
         XCTAssertTrue(comparisonThirtyTwo == testThirtyTwo, "These should be the same!")
     }
     
     func testThatJSONEncodableEncodesDouble() {
         let threePointOneFour = 3.14
-        let comparisonThreePointOneFour = JSON.Double(threePointOneFour)
+        let comparisonThreePointOneFour = JSON.double(threePointOneFour)
         let testThreePointOneFour = threePointOneFour.toJSON()
         XCTAssertTrue(comparisonThreePointOneFour == testThreePointOneFour, "These should be the same!")
     }
@@ -48,7 +48,7 @@ class JSONEncodableTests: XCTestCase {
     
     func testThatJSONEncodableEncodesArray() {
         let veggies = ["lettuce", "onion"]
-        let comparisonVeggies = JSON.Array(["lettuce", "onion"])
+        let comparisonVeggies = JSON.array(["lettuce", "onion"])
         let testVeggies = veggies.toJSON()
         XCTAssertTrue(comparisonVeggies == testVeggies, "These should be the same!")
     }

--- a/Tests/JSONSerializingTests.swift
+++ b/Tests/JSONSerializingTests.swift
@@ -26,14 +26,14 @@ class JSONSerializingTests: XCTestCase {
     }
 
     func testThatJSONSerializationHandlesBoolsCorrectly() {
-        let json = JSON.Dictionary([
-            "foo": .Bool(true),
-            "bar": .Bool(false),
-            "baz": .Int(123),
+        let json = JSON.dictionary([
+            "foo": .bool(true),
+            "bar": .bool(false),
+            "baz": .int(123),
         ])
         let data = try! json.serialize()
-        let deserializedResult = try! JSON(data: data).dictionary()
-        let deserialized = JSON.Dictionary(deserializedResult)
+        let deserializedResult = try! JSON(data: data).getDictionary()
+        let deserialized = JSON.dictionary(deserializedResult)
         XCTAssertEqual(json, deserialized, "Serialize/Deserialize succeed with Bools")
     }
 }
@@ -46,7 +46,7 @@ func dataFromFixture(_ filename: String) -> Data {
     }
 
     guard let data = try? Data(contentsOf: URL) else {
-        preconditionFailure("NSData failed to read file \(URL.path)")
+        preconditionFailure("Data failed to read file \(URL.path)")
     }
     return data
 }

--- a/Tests/JSONSubscriptingTests.swift
+++ b/Tests/JSONSubscriptingTests.swift
@@ -22,7 +22,7 @@ class JSONSubscriptingTests: XCTestCase {
     override func setUp() {
         super.setUp()
         
-        residentJSON = JSON.Dictionary([
+        residentJSON = .dictionary([
             "residents": [
                 ["name": "Matt", "age": 33, "hasPet": false, "rent": .null],
                 ["name": "Drew", "hasPet": true, "rent": 1234.5],
@@ -31,7 +31,7 @@ class JSONSubscriptingTests: XCTestCase {
             "residentsByName": [
                 "Matt": ["name": "Matt", "age": 33, "hasPet": false, "rent": .null],
                 "Drew": ["name": "Drew", "hasPet": true, "rent": 1234.5],
-                "Pat": ["name": "Pat", "age": 28, "hasPet": .null]
+                "Pat":  ["name": "Pat", "age": 28, "hasPet": .null]
             ]
             ])
         
@@ -58,7 +58,7 @@ class JSONSubscriptingTests: XCTestCase {
     
     func testThatArrayOfProducesResidents() {
         do {
-            let residents = try residentJSON.arrayOf("residents", type: Resident.self)
+            let residents = try residentJSON.decodedArray(at: "residents", type: Resident.self)
             let residentsNames = residents.map { $0.name }
             XCTAssertEqual(residentsNames.count, 3, "There should be 3 residents.")
         } catch {
@@ -68,7 +68,7 @@ class JSONSubscriptingTests: XCTestCase {
     
     func testThatDictionaryOfProducesResidentsByName() {
         do {
-            let residentsByName = try residentJSON.dictionaryOf("residentsByName", type: Resident.self)
+            let residentsByName = try residentJSON.decodedDictionary(at: "residentsByName", type: Resident.self)
             let residentsNames = residentsByName.map { $1.name }
             XCTAssertEqual(residentsNames.count, 3, "There should be 3 residents.")
         } catch {
@@ -78,7 +78,7 @@ class JSONSubscriptingTests: XCTestCase {
     
     func testNullOptionsDecodes() {
         do {
-            let firstResident = try residentJSON.decode("residents", 0, alongPath: [.NullBecomesNil, .MissingKeyBecomesNil], type: Resident.self)
+            let firstResident = try residentJSON.decode(at: "residents", 0, alongPath: [.NullBecomesNil, .MissingKeyBecomesNil], type: Resident.self)
             XCTAssertNotNil(firstResident)
         } catch {
             XCTFail("There should be no error: \(error).")
@@ -87,7 +87,7 @@ class JSONSubscriptingTests: XCTestCase {
     
     func testNullOptionsProducesOptionalForNotFoundWithArrayOf() {
         do {
-            let residents = try residentJSON.arrayOf("residents", type: Resident.self)
+            let residents = try residentJSON.decodedArray(at: "residents", type: Resident.self)
             XCTAssertNil(residents[1].age, "Drew's `age` should be nil.")
         } catch {
             XCTFail("There should be no error.")
@@ -96,7 +96,7 @@ class JSONSubscriptingTests: XCTestCase {
     
     func testNullOptionsProducesOptionalForNotFoundWithDictionaryOf() {
         do {
-            let residents = try residentJSON.dictionaryOf("residentsByName", type: Resident.self)
+            let residents = try residentJSON.decodedDictionary(at: "residentsByName", type: Resident.self)
             XCTAssertNotNil(residents["Drew"])
             XCTAssertNil(residents["Drew"]?.age, "Drew's `age` should be nil.")
         } catch {
@@ -106,7 +106,7 @@ class JSONSubscriptingTests: XCTestCase {
     
     func testNullOptionsProducesOptionalForNullOrNotFoundWithArrayOf() {
         do {
-            let residents = try residentJSON.arrayOf("residents", type: Resident.self)
+            let residents = try residentJSON.decodedArray(at: "residents", type: Resident.self)
             XCTAssertNil(residents.first?.rent, "Matt should have nil `rent`.")
             XCTAssertEqual(residents[1].rent!, 1234.5, "Drew's `rent` should equal 1234.5.")
             XCTAssertNil(residents.last?.rent, "Pat should have nil `rent`.")
@@ -117,7 +117,7 @@ class JSONSubscriptingTests: XCTestCase {
     
     func testNullOptionsProducesOptionalForNullOrNotFoundWithDictionaryOf() {
         do {
-            let residents = try residentJSON.dictionaryOf("residentsByName", type: Resident.self)
+            let residents = try residentJSON.decodedDictionary(at: "residentsByName", type: Resident.self)
             XCTAssertNotNil(residents["Matt"])
             XCTAssertNil(residents["Matt"]?.rent, "Matt should have nil `rent`.")
             XCTAssertEqual(residents["Drew"]!.rent!, 1234.5, "Drew's `rent` should equal 1234.5.")
@@ -130,7 +130,7 @@ class JSONSubscriptingTests: XCTestCase {
     
     func testNullOptionsIndexOutOfBoundsProducesOptional() {
         do {
-            let residentOutOfBounds = try residentJSON.decode("residents", 4, alongPath: .MissingKeyBecomesNil, type: Resident.self)
+            let residentOutOfBounds = try residentJSON.decode(at: "residents", 4, alongPath: .MissingKeyBecomesNil, type: Resident.self)
             XCTAssertNil(residentOutOfBounds)
         } catch {
             XCTFail("There should be no error: \(error).")
@@ -140,7 +140,7 @@ class JSONSubscriptingTests: XCTestCase {
     func testArrayOfJSONIntAndNullCreatesOptionalWhenDetectNull() {
         let testJSON: JSON = [1,2,.null,4]
         do {
-            _ = try testJSON.arrayOf(alongPath: .NullBecomesNil, type: Int.self)
+            _ = try testJSON.decodedArray(alongPath: .NullBecomesNil, type: Int.self)
             XCTFail("`testJSON.arrayOf(_:options:type:)` should throw.")
         } catch let JSON.Error.valueNotConvertible(value, type) {
             XCTAssert(type == Int.self, "value (\(value)) is not equal to \(type).")
@@ -152,8 +152,8 @@ class JSONSubscriptingTests: XCTestCase {
     func testArrayProducesOptionalWhenNotFoundOrNull() {
         let testJSON: JSON = ["integers": .null]
         do {
-            let test1 = try testJSON.array("integers", alongPath: .NullBecomesNil)
-            let test2 = try testJSON.array("residents", alongPath: .MissingKeyBecomesNil)
+            let test1 = try testJSON.getArray(at: "integers", alongPath: .NullBecomesNil)
+            let test2 = try testJSON.getArray(at: "residents", alongPath: .MissingKeyBecomesNil)
             XCTAssertNil(test1, "Test1 should be nil.")
             XCTAssertNil(test2, "Test2 should be nil.")
         } catch {
@@ -164,7 +164,7 @@ class JSONSubscriptingTests: XCTestCase {
     func testDictionaryOfJSONIntAndNullCreatesOptionalWhenDetectNull() {
         let testJSON: JSON = ["one": 1, "two": 2, "three": .null, "four": 4]
         do {
-            _ = try testJSON.dictionaryOf(alongPath: .NullBecomesNil, type: Int.self)
+            _ = try testJSON.decodedDictionary(alongPath: .NullBecomesNil, type: Int.self)
             XCTFail("`testJSON.dictionaryOf(_:options:type:)` should throw.")
         } catch let JSON.Error.valueNotConvertible(value, type) {
             XCTAssert(type == Int.self, "value (\(value)) is not equal to \(type).")
@@ -176,8 +176,8 @@ class JSONSubscriptingTests: XCTestCase {
     func testDictionaryProducesOptionalWhenNotFoundOrNull() {
         let testJSON: JSON = ["integers": .null]
         do {
-            let test1 = try testJSON.dictionary("integers", alongPath: .NullBecomesNil)
-            let test2 = try testJSON.dictionary("residents", alongPath: .MissingKeyBecomesNil)
+            let test1 = try testJSON.getDictionary(at: "integers", alongPath: .NullBecomesNil)
+            let test2 = try testJSON.getDictionary(at: "residents", alongPath: .MissingKeyBecomesNil)
             XCTAssertNil(test1, "Test1 should be nil.")
             XCTAssertNil(test2, "Test2 should be nil.")
         } catch {
@@ -187,7 +187,7 @@ class JSONSubscriptingTests: XCTestCase {
     
     func testJSONDictionaryUnexpectedSubscript() {
         do {
-            _ = try residentJSON.decode(1, type: Resident.self)
+            _ = try residentJSON.decode(at: 1, type: Resident.self)
             XCTFail("Should throw error.")
         } catch JSON.Error.unexpectedSubscript(type: let theType) {
             XCTAssertTrue(theType is Int.Type)
@@ -208,7 +208,7 @@ class JSONSubscriptingTests: XCTestCase {
     
     func testDecodeOr() {
         do {
-            let outOfBounds = try residentJSON.decode("residents", 4, or: Resident(name: "NA", age: 30, hasPet: false, rent: 0))
+            let outOfBounds = try residentJSON.decode(at: "residents", 4, or: Resident(name: "NA", age: 30, hasPet: false, rent: 0))
             XCTAssertTrue(outOfBounds.name == "NA")
         } catch {
             XCTFail("There should be no error: \(error).")
@@ -217,7 +217,7 @@ class JSONSubscriptingTests: XCTestCase {
     
     func testDoubleOr() {
         do {
-            let rent = try residentJSON.double("residents", 2, "rent", or: 0)
+            let rent = try residentJSON.getDouble(at: "residents", 2, "rent", or: 0)
             XCTAssertTrue(rent == 0, "Rent should be free.")
         } catch {
             XCTFail("There should be no error: \(error).")
@@ -226,7 +226,7 @@ class JSONSubscriptingTests: XCTestCase {
     
     func testStringOr() {
         do {
-            let nickname = try residentJSON.string("residents", 0, "nickname", or: "DubbaDubs")
+            let nickname = try residentJSON.getString(at: "residents", 0, "nickname", or: "DubbaDubs")
             XCTAssertTrue(nickname == "DubbaDubs")
         } catch {
             XCTFail("There should be no error: \(error).")
@@ -235,7 +235,7 @@ class JSONSubscriptingTests: XCTestCase {
     
     func testIntOr() {
         do {
-            let age = try residentJSON.int("residents", 1, "age", or: 21)
+            let age = try residentJSON.getInt(at: "residents", 1, "age", or: 21)
             XCTAssertTrue(age == 21, "Forever young!")
         } catch {
             XCTFail("There should be no error: \(error).")
@@ -244,7 +244,7 @@ class JSONSubscriptingTests: XCTestCase {
     
     func testBoolOr() {
         do {
-            let hasSpouse = try residentJSON.bool("residents", 1, "hasSpouse", or: false)
+            let hasSpouse = try residentJSON.getBool(at: "residents", 1, "hasSpouse", or: false)
             XCTAssertFalse(hasSpouse, "No spouse")
         } catch {
             XCTFail("There should be no error: \(error).")
@@ -255,7 +255,7 @@ class JSONSubscriptingTests: XCTestCase {
         do {
             let testJSON: JSON = ["pets": .null]
             let defaultArrayOfJSON: [JSON] = ["Oink", "Snuggles"]
-            let pets = try testJSON.array("pet", or: defaultArrayOfJSON)
+            let pets = try testJSON.getArray(at: "pet", or: defaultArrayOfJSON)
             XCTAssertEqual(pets, defaultArrayOfJSON, "`pets` should equal the `defaultArrayOfJSON`.")
         } catch {
             XCTFail("There should be no error: \(error).")
@@ -265,7 +265,7 @@ class JSONSubscriptingTests: XCTestCase {
     func testArrayOfOr() {
         do {
             let matt = Resident(name: "Matt", age: 32, hasPet: false, rent: 500.00)
-            let residentsOr = try residentJSON.arrayOf("residnts", or: [matt])
+            let residentsOr = try residentJSON.decodedArray(at: "residnts", or: [matt])
             XCTAssertEqual(residentsOr.first!, matt, "`residents` should not be nil")
         } catch {
             XCTFail("There should be no error: \(error).")
@@ -275,7 +275,7 @@ class JSONSubscriptingTests: XCTestCase {
     func testDictionaryOr() {
         do {
             let jsonDict: [String: JSON] = ["name": "Matt", "age": 33, "hasPet": false, "rent": .null]
-            let mattOr = try residentJSON.dictionary("residents", 4, or: jsonDict)
+            let mattOr = try residentJSON.getDictionary(at: "residents", 4, or: jsonDict)
             XCTAssertEqual(jsonDict, mattOr, "`jsonDict` should equal `mattOr`")
         } catch {
             XCTFail("There should be no error: \(error).")
@@ -285,7 +285,7 @@ class JSONSubscriptingTests: XCTestCase {
     func testDictionaryOfOr() {
         do {
             let matt = Resident(name: "Matt", age: 32, hasPet: false, rent: 500.00)
-            let residentsOr = try residentJSON.dictionaryOf("residnts", or: ["Matt": matt])
+            let residentsOr = try residentJSON.decodedDictionary(at: "residnts", or: ["Matt": matt])
             XCTAssertEqual(residentsOr, ["Matt": matt], "`residents` should not be nil")
         } catch {
             XCTFail("There should be no error: \(error).")
@@ -294,7 +294,7 @@ class JSONSubscriptingTests: XCTestCase {
     
     func testThatUnexpectedSubscriptIsThrown() {
         do {
-            _ = try residentJSON.decode("residents", 1, "name", "initial", type: Resident.self)
+            _ = try residentJSON.decode(at: "residents", 1, "name", "initial", type: Resident.self)
         } catch JSON.Error.unexpectedSubscript(let type) {
             XCTAssert(type == Swift.String, "The dictionary at index 1 should not be subscriptable by: \(type).")
         } catch {
@@ -304,7 +304,7 @@ class JSONSubscriptingTests: XCTestCase {
     
     func testMissingKeyOptionStillFailsIfNullEncountered() {
         do {
-            let json = JSON.Dictionary([
+            let json = JSON.dictionary([
                 "name": "Drew",
                 "age": nil, // should cause problems!
                 "hasPet": true,
@@ -321,7 +321,7 @@ class JSONSubscriptingTests: XCTestCase {
     
     func testSubscriptingOptionsStillFailIfKeyIsMissing() {
         do {
-            let json = JSON.Dictionary([
+            let json = JSON.dictionary([
                 "name": "Drew",
                 "rent": 1234.5,
                 ])
@@ -335,7 +335,7 @@ class JSONSubscriptingTests: XCTestCase {
     }
     
     func testThatMapCanCreateArrayOfPeople() {
-        let peopleJSON = try! json.array("people")
+        let peopleJSON = try! json.getArray(at: "people")
         let people = try! peopleJSON.map(Person.init)
         for person in people {
             XCTAssertNotEqual(person.name, "", "There should be a name.")
@@ -343,24 +343,24 @@ class JSONSubscriptingTests: XCTestCase {
     }
     
     func testThatSubscriptingJSONWorksForTopLevelObject() {
-        let success = try? json.bool("success")
+        let success = try? json.getBool(at: "success")
         XCTAssertEqual(success, true, "There should be `success`.")
     }
     
     func testThatPathSubscriptingPerformsNesting() {
-        for z in try! json.array("states", "Georgia") {
-            XCTAssertNotNil(try? z.int(), "The `Int` should not be `nil`.")
+        for z in try! json.getArray(at: "states", "Georgia") {
+            XCTAssertNotNil(try? z.getInt(), "The `Int` should not be `nil`.")
         }
     }
     
     func testJSONSubscriptWithInt() {
-        let mattmatt = try? json.string("people", 0, "name")
+        let mattmatt = try? json.getString(at: "people", 0, "name")
         XCTAssertEqual(mattmatt, "Matt Mathias", "`matt` should hold string `Matt Mathias`")
     }
     
     func testJSONErrorKeyNotFound() {
         do {
-            _ = try json.array("peopl")
+            _ = try json.getArray(at: "peopl")
         } catch JSON.Error.keyNotFound(let key) {
             XCTAssert(key == "peopl", "The error should be due to the key not being found.")
         } catch {
@@ -370,7 +370,7 @@ class JSONSubscriptingTests: XCTestCase {
     
     func testJSONErrorIndexOutOfBounds() {
         do {
-            _ = try json.dictionary("people", 4)
+            _ = try json.getDictionary(at: "people", 4)
         } catch JSON.Error.indexOutOfBounds(let index) {
             XCTAssert(index == 4, "The error should be due to the index being out of bounds.")
         } catch {
@@ -380,7 +380,7 @@ class JSONSubscriptingTests: XCTestCase {
     
     func testJSONErrorTypeNotConvertible() {
         do {
-            _ = try json.int("people", 0, "name")
+            _ = try json.getInt(at: "people", 0, "name")
         } catch let JSON.Error.valueNotConvertible(value, to) {
             XCTAssert(to == Swift.Int, "The error should be due the value not being an `Int` case, but was \(to).")
             XCTAssert(value == "Matt Mathias", "The error should be due the value being the String 'Matt Mathias', but was \(value).")
@@ -391,7 +391,7 @@ class JSONSubscriptingTests: XCTestCase {
     
     func testJSONErrorUnexpectedSubscript() {
         do {
-            _ = try json.string("people", "name")
+            _ = try json.getString(at: "people", "name")
         } catch JSON.Error.unexpectedSubscript(let type) {
             XCTAssert(type == Swift.String, "The error should be due the value not being subscriptable with string `String` case, but was \(type).")
         } catch {
@@ -400,14 +400,14 @@ class JSONSubscriptingTests: XCTestCase {
     }
     
     func testThatOptionalSubscriptingIntoNullSucceeds() {
-        let earlyNull = [ "foo": nil ] as JSON
-        let string = try! earlyNull.string("foo", "bar", "baz", alongPath: .NullBecomesNil)
+        let earlyNull = ["foo": nil] as JSON
+        let string = try! earlyNull.getString(at: "foo", "bar", "baz", alongPath: .NullBecomesNil)
         XCTAssertNil(string)
     }
     
     func testThatOptionalSubscriptingKeyNotFoundSucceeds() {
-        let keyNotFound = [ "foo": 2 ] as JSON
-        let string = try! keyNotFound.string("bar", alongPath: .MissingKeyBecomesNil)
+        let keyNotFound = ["foo": 2] as JSON
+        let string = try! keyNotFound.getString(at: "bar", alongPath: .MissingKeyBecomesNil)
         XCTAssertNil(string)
     }
     
@@ -422,10 +422,10 @@ private struct Resident {
 
 extension Resident: JSONDecodable {
     fileprivate init(json: JSON) throws {
-        name = try json.string("name")
-        age = try json.int("age", alongPath: .MissingKeyBecomesNil)
-        hasPet = try json.bool("hasPet", alongPath: .NullBecomesNil)
-        rent = try json.double("rent", alongPath: [.NullBecomesNil, .MissingKeyBecomesNil])
+        name = try json.getString(at: "name")
+        age = try json.getInt(at: "age", alongPath: .MissingKeyBecomesNil)
+        hasPet = try json.getBool(at: "hasPet", alongPath: .NullBecomesNil)
+        rent = try json.getDouble(at: "rent", alongPath: [.NullBecomesNil, .MissingKeyBecomesNil])
     }
 }
 
@@ -450,25 +450,25 @@ class JSONSubscriptWithNSJSONTests: JSONSubscriptingTests {
 private func testUsage() {
     let j = JSON.null
     
-    _ = try? j.int()
-    _ = try? j.int(alongPath: .MissingKeyBecomesNil)
-    _ = try? j.int(alongPath: .NullBecomesNil)
-    _ = try? j.int(or: 42)
+    _ = try? j.getInt()
+    _ = try? j.getInt(alongPath: .MissingKeyBecomesNil)
+    _ = try? j.getInt(alongPath: .NullBecomesNil)
+    _ = try? j.getInt(or: 42)
     
-    _ = try? j.int("key")
-    _ = try? j.int("key", alongPath: .MissingKeyBecomesNil)
-    _ = try? j.int("key", alongPath: .NullBecomesNil)
-    _ = try? j.int("key", or: 42)
+    _ = try? j.getInt(at: "key")
+    _ = try? j.getInt(at: "key", alongPath: .MissingKeyBecomesNil)
+    _ = try? j.getInt(at: "key", alongPath: .NullBecomesNil)
+    _ = try? j.getInt(at: "key", or: 42)
     
-    _ = try? j.int(1)
-    _ = try? j.int(2, alongPath: .MissingKeyBecomesNil)
-    _ = try? j.int(3, alongPath: .NullBecomesNil)
-    _ = try? j.int(4, or: 42)
+    _ = try? j.getInt(at: 1)
+    _ = try? j.getInt(at: 2, alongPath: .MissingKeyBecomesNil)
+    _ = try? j.getInt(at: 3, alongPath: .NullBecomesNil)
+    _ = try? j.getInt(at: 4, or: 42)
     
     let stringConst = "key"
     
-    _ = try? j.int(stringConst, 1)
-    _ = try? j.int(stringConst, 2, alongPath: .MissingKeyBecomesNil)
-    _ = try? j.int(stringConst, 3, alongPath: .NullBecomesNil)
-    _ = try? j.int(stringConst, 4, or: 42)
+    _ = try? j.getInt(at: stringConst, 1)
+    _ = try? j.getInt(at: stringConst, 2, alongPath: .MissingKeyBecomesNil)
+    _ = try? j.getInt(at: stringConst, 3, alongPath: .NullBecomesNil)
+    _ = try? j.getInt(at: stringConst, 4, or: 42)
 }

--- a/Tests/JSONTypeTests.swift
+++ b/Tests/JSONTypeTests.swift
@@ -12,71 +12,71 @@ import Freddy
 class JSONTypeTests: XCTestCase {
     
     func testCastInitializeArray() {
-        let array = [ JSON.Int(1), JSON.Int(2), JSON.Int(3) ]
-        let expected = JSON.Array(array)
+        let array: [JSON] = [1, 2, 3]
+        let expected = JSON.array(array)
         let json = JSON(array)
         XCTAssertEqual(json, expected)
     }
 
     func testCastInitializeAnyCollection() {
-        let collection = (1 ... 3).lazy.map { JSON.Int($0) }
-        let expected = JSON.Array([ JSON.Int(1), JSON.Int(2), JSON.Int(3) ])
+        let collection = (1 ... 3).lazy.map { JSON.int($0) }
+        let expected: JSON = .array([1, 2, 3])
         let json = JSON(collection)
         XCTAssertEqual(json, expected)
     }
 
     func testCastInitializeDictionary() {
-        let dictionary = [ "foo" : JSON.Int(1), "bar" : JSON.Int(2), "baz" : JSON.Int(3)]
-        let expected = JSON.Dictionary(dictionary)
+        let dictionary: [String:JSON] = ["foo": 1, "bar": 2, "baz": 3]
+        let expected = JSON.dictionary(dictionary)
         let json = JSON(dictionary)
         XCTAssertEqual(json, expected)
     }
 
     func testCastInitializeAnyDictionary() {
-        let dictionary = [ "foo": 1, "bar": 2, "baz": 3 ]
+        let dictionary = ["foo": 1, "bar": 2, "baz": 3]
         let pairCollection = dictionary.lazy.map { (key, value) in
             (key, JSON(value * 2))
         }
-        let expected = JSON.Dictionary([ "foo": JSON.Int(2), "bar": JSON.Int(4), "baz": JSON.Int(6) ])
+        let expected: JSON = .dictionary(["foo": 2, "bar": 4, "baz": 6])
         let json = JSON(pairCollection)
         XCTAssertEqual(json, expected)
     }
 
     func testCastInitializeDouble() {
         let double = 42.0 as Double
-        let expected = JSON.Double(double)
+        let expected = JSON.double(double)
         let json = JSON(double)
         XCTAssertEqual(json, expected)
     }
 
     func testCastInitializeInt() {
         let int = 65535 as Int
-        let expected = JSON.Int(int)
+        let expected = JSON.int(int)
         let json = JSON(int)
         XCTAssertEqual(json, expected)
     }
 
     func testCastInitializeString() {
         let string = "Don't Panic"
-        let expected = JSON.String(string)
+        let expected = JSON.string(string)
         let json = JSON(string)
         XCTAssertEqual(json, expected)
     }
 
     func testCastInitializeBool() {
         let bool = false
-        let expected = JSON.Bool(bool)
+        let expected = JSON.bool(bool)
         let json = JSON(bool)
         XCTAssertEqual(json, expected)
     }
 
     func testLiteralConversion() {
-        let valueNotLiteral: JSON = .Dictionary([
-            "someKey": .Array([
-                .Dictionary([ "children": .Array([ .String("a string") ]) ]),
-                .Dictionary([ "children": .Array([ .String("\u{00E9}"), .String("\u{00E9}") ]) ]),
-                .Dictionary([ "children": .Array([ .String("\u{1F419}"), .String("\u{1F419}") ]) ]),
-                .Dictionary([ "children": .Array([ .Double(42.0), .Int(65535), .Bool(true), .null ]) ])
+        let valueNotLiteral: JSON = .dictionary([
+            "someKey": .array([
+                .dictionary([ "children": .array([ .string("a string") ]) ]),
+                .dictionary([ "children": .array([ .string("\u{00E9}"), .string("\u{00E9}") ]) ]),
+                .dictionary([ "children": .array([ .string("\u{1F419}"), .string("\u{1F419}") ]) ]),
+                .dictionary([ "children": .array([ .double(42.0), .int(65535), .bool(true), .null ]) ])
             ])
         ])
         

--- a/Tests/Person.swift
+++ b/Tests/Person.swift
@@ -30,15 +30,15 @@ extension Person.EyeColor: JSONEncodable {}
 
 extension Person: JSONDecodable {
     public init(json value: JSON) throws {
-        name = try value.string("name")
-        age = try value.int("age")
-        eyeColor = try value.decode("eyeColor")
-        spouse = try value.bool("spouse")
+        name = try value.getString(at: "name")
+        age = try value.getInt(at: "age")
+        eyeColor = try value.decode(at: "eyeColor")
+        spouse = try value.getBool(at: "spouse")
     }
 }
 
 extension Person: JSONEncodable {
     public func toJSON() -> JSON {
-        return .Dictionary(["name": .String(name), "age": .Int(age), "eyeColor": eyeColor.toJSON(), "spouse": .Bool(spouse)])
+        return .dictionary(["name": .string(name), "age": .int(age), "eyeColor": eyeColor.toJSON(), "spouse": .bool(spouse)])
     }
 }


### PR DESCRIPTION
This PR allows for Freddy to be pulled in using cocoapods. Currently Cocoapods isn't setting the SWIFT_VERSION compiler setting to anything, so Freddy will not build. Looking at the current issues/PRs for cocoapods, it is unclear if they have a real solution to this or not. Ideally each pod should have a say into which swift version it supports. This change allows us to control the version from the podspec. We can revisit once cocoapods has a real solution for this problem.