### PR TITLE
Remove unnecessary `NSString` cast

### DIFF
--- a/Sources/JSONParsing.swift
+++ b/Sources/JSONParsing.swift
@@ -31,7 +31,7 @@ extension JSON {
 
     /// Create `JSON` from UTF-8 `string`.
     public init(jsonString: Swift.String, usingParser parser: JSONParserType.Type = JSONParser.self) throws {
-        self = try parser.createJSON(from: (jsonString as NSString).data(using: Swift.String.Encoding.utf8.rawValue) ?? Data())
+        self = try parser.createJSON(from: jsonString.data(using: Swift.String.Encoding.utf8) ?? Data())
     }
 }
 


### PR DESCRIPTION
Remove a case that was not necessary as well as clean up enum syntax.

Although a small change, feedback is welcome if some other style is preferred, but figured it would be best to avoid unnecessary casts.