### PR TITLE
Do not crash when string ends in backslash

### DIFF
--- a/Sources/JSONParser.swift
+++ b/Sources/JSONParser.swift
@@ -237,6 +237,7 @@ public struct JSONParser {
             switch input[loc] {
             case Literal.BACKSLASH:
                 loc = (loc + 1)
+                if loc >= input.count { continue }
                 switch input[loc] {
                 case Literal.DOUBLE_QUOTE: stringDecodingBuffer.append(Literal.DOUBLE_QUOTE)
                 case Literal.BACKSLASH:    stringDecodingBuffer.append(Literal.BACKSLASH)

--- a/Tests/JSONParserTests.swift
+++ b/Tests/JSONParserTests.swift
@@ -482,4 +482,15 @@ class JSONParserTests: XCTestCase {
             }
         }
     }
+
+    func testThatParserRejectsStringEndingInBackslash() {
+        let invalidJSONString = "[\"\\"
+        do {
+            _ = try JSONParser.parse(invalidJSONString)
+        } catch JSONParser.Error.endOfStreamUnexpected {
+            // do nothing - this is the expected error
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
 }


### PR DESCRIPTION
The problem was that the parser would read beyond a backslash even if it
was the last character, so rather than reporting it as invalid JSON and
throwing an error it would try to read beyond the string and crash. This
fix just adds a check to ensure that the parser doesn't read out of
bounds.

Also added a test to handle this case.

I'm still not very familiar with the code base, so if there are any styles nits, or any other feedback I'd be grateful!
