### PR TITLE
Supports JSONStaticDecodable

### DIFF
--- a/Freddy.xcodeproj/project.pbxproj
+++ b/Freddy.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		3F70EA981C6D0EC500972CEB /* JSONSerializingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F70EA971C6D0EC500972CEB /* JSONSerializingTests.swift */; };
 		3F70EA991C6D0EC500972CEB /* JSONSerializingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F70EA971C6D0EC500972CEB /* JSONSerializingTests.swift */; };
 		3F70EA9A1C6D0EC500972CEB /* JSONSerializingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F70EA971C6D0EC500972CEB /* JSONSerializingTests.swift */; };
+		CE265FF51DAFBF99007FF7CF /* JSONStaticDecodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE265FF31DAFBEB2007FF7CF /* JSONStaticDecodableTests.swift */; };
 		DB6ADF231C23610B00D77BF1 /* Freddy.h in Headers */ = {isa = PBXBuildFile; fileRef = DB6ADF221C23610B00D77BF1 /* Freddy.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DB6ADF2A1C23610B00D77BF1 /* Freddy.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB6ADF1F1C23610B00D77BF1 /* Freddy.framework */; };
 		DB6ADF481C23612000D77BF1 /* Freddy.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB6ADF3E1C23612000D77BF1 /* Freddy.framework */; };
@@ -115,6 +116,7 @@
 		1C7BD51E1C7A4B9300A6ED4B /* JSONSubscriptingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONSubscriptingTests.swift; sourceTree = "<group>"; };
 		3F70EA921C6D0D2B00972CEB /* JSONSerializing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONSerializing.swift; sourceTree = "<group>"; };
 		3F70EA971C6D0EC500972CEB /* JSONSerializingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONSerializingTests.swift; sourceTree = "<group>"; };
+		CE265FF31DAFBEB2007FF7CF /* JSONStaticDecodableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONStaticDecodableTests.swift; sourceTree = "<group>"; };
 		DB6ADF1F1C23610B00D77BF1 /* Freddy.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Freddy.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DB6ADF221C23610B00D77BF1 /* Freddy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Freddy.h; sourceTree = "<group>"; };
 		DB6ADF241C23610B00D77BF1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -257,6 +259,7 @@
 				1C7BD51E1C7A4B9300A6ED4B /* JSONSubscriptingTests.swift */,
 				DB6ADFAF1C2362FF00D77BF1 /* JSONTypeTests.swift */,
 				E43B67DF1C5962CD00ACE390 /* JSONEncodingDetectorTests.swift */,
+				CE265FF31DAFBEB2007FF7CF /* JSONStaticDecodableTests.swift */,
 				DB6ADFC01C23630500D77BF1 /* Fixtures */,
 				DB6ADF301C23610B00D77BF1 /* Info.plist */,
 			);
@@ -630,6 +633,7 @@
 				E43B67E01C5962CD00ACE390 /* JSONEncodingDetectorTests.swift in Sources */,
 				DB6ADFB11C2362FF00D77BF1 /* JSONDecodableTests.swift in Sources */,
 				DC194EB91C47D87B001D4569 /* JSONTests.swift in Sources */,
+				CE265FF51DAFBF99007FF7CF /* JSONStaticDecodableTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/JSONDecodable.swift
+++ b/Sources/JSONDecodable.swift
@@ -19,6 +19,8 @@ public protocol JSONDecodable {
     
 }
 
+/// A protocol to provide functionality for creating a model object with a `JSON`
+/// value. Useful for extension for class. Only works for `final` classes
 public protocol JSONStaticDecodable {
     
     static func fromJSON(json: JSON) throws -> Self

--- a/Sources/JSONDecodable.swift
+++ b/Sources/JSONDecodable.swift
@@ -19,6 +19,11 @@ public protocol JSONDecodable {
     
 }
 
+public protocol JSONStaticDecodable {
+    
+    static func fromJSON(json: JSON) throws -> Self
+}
+
 extension Double: JSONDecodable {
     
     /// An initializer to create an instance of `Double` from a `JSON` value.
@@ -156,6 +161,12 @@ internal extension JSON {
         return try getArray(from: json).map(Decoded.init)
     }
     
+    static func decodedArray<Decoded: JSONStaticDecodable>(from json: JSON) throws -> [Decoded] {
+        // Ideally should be expressed as a conditional protocol implementation on Swift.Dictionary.
+        // This implementation also doesn't do the `type = Type.self` trick.
+        return try getArray(from: json).map(Decoded.fromJSON)
+    }
+    
     /// Attempts to decode many values from a descendant JSON object at a path
     /// into JSON.
     /// - parameter json: A `JSON` to be used to create the returned `Dictionary` of some type conforming to `JSONDecodable`.
@@ -170,6 +181,17 @@ internal extension JSON {
         var decodedDictionary = Swift.Dictionary<String, Decoded>(minimumCapacity: dictionary.count)
         for (key, value) in dictionary {
             decodedDictionary[key] = try Decoded(json: value)
+        }
+        return decodedDictionary
+    }
+    
+    static func decodedDictionary<Decoded: JSONStaticDecodable>(from json: JSON) throws -> [Swift.String: Decoded] {
+        guard case let .dictionary(dictionary) = json else {
+            throw Error.valueNotConvertible(value: json, to: Swift.Dictionary<String, Decoded>)
+        }
+        var decodedDictionary = Swift.Dictionary<String, Decoded>(minimumCapacity: dictionary.count)
+        for (key, value) in dictionary {
+            decodedDictionary[key] = try Decoded.fromJSON(json: value)
         }
         return decodedDictionary
     }

--- a/Sources/JSONSubscripting.swift
+++ b/Sources/JSONSubscripting.swift
@@ -208,6 +208,10 @@ extension JSON {
     public func decodedArray<Decoded: JSONDecodable>(at path: JSONPathType..., type: Decoded.Type = Decoded.self) throws -> [Decoded] {
         return try JSON.decodedArray(from: value(at: path))
     }
+    
+    public func decodedArray<Decoded: JSONStaticDecodable>(at path: JSONPathType..., type: Decoded.Type = Decoded.self) throws -> [Decoded] {
+        return try JSON.decodedArray(from: value(at: path))
+    }
 
     /// Retrieves a `[String: JSON]` from a path into JSON.
     /// - parameter path: 0 or more `String` or `Int` that subscript the `JSON`

--- a/Sources/JSONSubscripting.swift
+++ b/Sources/JSONSubscripting.swift
@@ -145,6 +145,10 @@ extension JSON {
     public func decode<Decoded: JSONDecodable>(at path: JSONPathType..., type: Decoded.Type = Decoded.self) throws -> Decoded {
         return try Decoded(json: value(at: path))
     }
+    
+    public func decode<Decoded: JSONStaticDecodable>(at path: JSONPathType..., type: Decoded.Type = Decoded.self) throws -> Decoded {
+        return try Decoded.fromJSON(json: value(at: path))
+    }
 
     /// Retrieves a `Double` from a path into JSON.
     /// - parameter path: 0 or more `String` or `Int` that subscript the `JSON`
@@ -228,6 +232,9 @@ extension JSON {
         return try JSON.decodedDictionary(from: value(at: path))
     }
 
+    public func decodedDictionary<Decoded: JSONStaticDecodable>(at path: JSONPathType..., type: Decoded.Type = Decoded.self) throws -> [String: Decoded] {
+        return try JSON.decodedDictionary(from: value(at: path))
+    }
 }
 
 // MARK: - NotFound-Or-Null-to-Optional unpacking
@@ -281,6 +288,13 @@ extension JSON {
         return try Decoded.init(json: json)
     }
     
+    private static func getDecoded<Decoded: JSONStaticDecodable>(json: JSON) throws -> Decoded {
+        guard json != .null else {
+            throw Error.valueNotConvertible(value: json, to: Decoded.self)
+        }
+        return try Decoded.fromJSON(json: json)
+    }
+    
     /// Optionally decodes into the returning type from a path into JSON.
     /// - parameter path: 0 or more `String` or `Int` that subscript the `JSON`
     /// - parameter alongPath: Options that control what should be done with values that are `null` or keys that are missing.
@@ -299,6 +313,10 @@ extension JSON {
     ///     instance does not match the decoded value.
     ///   * Any error that arises from decoding the value.
     public func decode<Decoded: JSONDecodable>(at path: JSONPathType..., alongPath options: SubscriptingOptions, type: Decoded.Type = Decoded.self) throws -> Decoded? {
+        return try mapOptional(at: path, alongPath: options, transform: JSON.getDecoded)
+    }
+    
+    public func decode<Decoded: JSONStaticDecodable>(at path: JSONPathType..., alongPath options: SubscriptingOptions, type: Decoded.Type = Decoded.self) throws -> Decoded? {
         return try mapOptional(at: path, alongPath: options, transform: JSON.getDecoded)
     }
 
@@ -409,6 +427,10 @@ extension JSON {
     public func decodedArray<Decoded: JSONDecodable>(at path: JSONPathType..., alongPath options: SubscriptingOptions, type: Decoded.Type = Decoded.self) throws -> [Decoded]? {
         return try mapOptional(at: path, alongPath: options, transform: JSON.decodedArray)
     }
+    
+    public func decodedArray<Decoded: JSONStaticDecodable>(at path: JSONPathType..., alongPath options: SubscriptingOptions, type: Decoded.Type = Decoded.self) throws -> [Decoded]? {
+        return try mapOptional(at: path, alongPath: options, transform: JSON.decodedArray)
+    }
 
     /// Optionally retrieves a `[String: JSON]` from a path into the recieving
     /// structure.
@@ -451,6 +473,10 @@ extension JSON {
     public func decodedDictionary<Decoded: JSONDecodable>(at path: JSONPathType..., alongPath options: SubscriptingOptions, type: Decoded.Type = Decoded.self) throws -> [String: Decoded]? {
         return try mapOptional(at: path, alongPath: options, transform: JSON.decodedDictionary)
     }
+    
+    public func decodedDictionary<Decoded: JSONStaticDecodable>(at path: JSONPathType..., alongPath options: SubscriptingOptions, type: Decoded.Type = Decoded.self) throws -> [String: Decoded]? {
+        return try mapOptional(at: path, alongPath: options, transform: JSON.decodedDictionary)
+    }
 
 }
 
@@ -474,6 +500,10 @@ extension JSON {
     ///     the `JSON` instance does not match `Decoded`.
     public func decode<Decoded: JSONDecodable>(at path: JSONPathType..., or fallback: @autoclosure() -> Decoded) throws -> Decoded {
         return try mapOptional(at: path, fallback: fallback, transform: Decoded.init)
+    }
+    
+    public func decode<Decoded: JSONStaticDecodable>(at path: JSONPathType..., or fallback: @autoclosure() -> Decoded) throws -> Decoded {
+        return try mapOptional(at: path, fallback: fallback, transform: Decoded.fromJSON)
     }
     
     /// Retrieves a `Double` from a path into JSON or a fallback if not found.
@@ -572,6 +602,10 @@ extension JSON {
         return try mapOptional(at: path, fallback: fallback, transform: JSON.decodedArray)
     }
     
+    public func decodedArray<Decoded: JSONStaticDecodable>(at path: JSONPathType..., or fallback: @autoclosure() -> [Decoded]) throws -> [Decoded] {
+        return try mapOptional(at: path, fallback: fallback, transform: JSON.decodedArray)
+    }
+    
     /// Retrieves a `[String: JSON]` from a path into JSON or a fallback if not
     /// found.
     /// - parameter path: 0 or more `String` or `Int` that subscript the `JSON`
@@ -606,6 +640,10 @@ extension JSON {
     ///     instance does not match the decoded value.
     ///   * Any error that arises from decoding the value.
     public func decodedDictionary<Decoded: JSONDecodable>(at path: JSONPathType..., or fallback: @autoclosure() -> [String: Decoded]) throws -> [String: Decoded] {
+        return try mapOptional(at: path, fallback: fallback, transform: JSON.decodedDictionary)
+    }
+    
+    public func decodedDictionary<Decoded: JSONStaticDecodable>(at path: JSONPathType..., or fallback: @autoclosure() -> [String: Decoded]) throws -> [String: Decoded] {
         return try mapOptional(at: path, fallback: fallback, transform: JSON.decodedDictionary)
     }
     

--- a/Tests/JSONStaticDecodableTests.swift
+++ b/Tests/JSONStaticDecodableTests.swift
@@ -1,0 +1,254 @@
+//
+//  JSONStaticDecodableTests.swift
+//  FreddyTests
+//
+//  Created by Matthew Mathias on 11/6/15.
+//  Modified by Mariotaku Lee on 10/13/16
+//  Copyright © 2015 Big Nerd Ranch. All rights reserved.
+//
+
+import XCTest
+import Freddy
+
+class JSONStaticDecodableTests: XCTestCase {
+    
+    private var mattJSON: JSON!
+    private var matt: PersonClass!
+    
+    override func setUp() {
+        super.setUp()
+        
+        mattJSON = ["name": "Matt Mathias", "age": 32, "eyeColor": "blue", "spouse": true]
+        matt = PersonClass(name: "Matt Mathias", age: 32, eyeColor: .Blue, spouse: true)
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    func testThatJSONDecodableConformanceProducesInstance() {
+        do {
+            let decodedMatt = try PersonClass.fromJSON(json: mattJSON)
+            XCTAssertEqual(matt, decodedMatt, "`matt` `decodedMatt` should be equal.")
+        } catch {
+            XCTFail("`matt` and `decodedMatt` are not equal: \(error).")
+        }
+    }
+    
+    func testJSONDecodableExtensionOnDouble() {
+        let fourPointFour = 4.4
+        let fourPointFourJSON: JSON = 4.4
+        let fourJSON: JSON = 4
+        
+        do {
+            let decodedFourPointFour = try Double(json: fourPointFourJSON)
+            let decodedFour = try Double(json: fourJSON)
+            XCTAssertEqual(decodedFourPointFour, fourPointFour, "`fourPointFourJSON` and `fourPointFour` should be equal.")
+            XCTAssertEqual(decodedFour, 4.0, "`decodedFour` and 4.0 should be equal.")
+        } catch {
+            XCTFail("Should be able to instantiate a `Double` with `JSON`: \(error).")
+        }
+        
+        do {
+            _ = try Double(json: "bad")
+            XCTFail("Should not be able to instantiate `Double` with `String` `JSON`.")
+        } catch JSON.Error.valueNotConvertible(let type) {
+            XCTAssert(true, "\(type) should not be covertible from 'bad' `String`.")
+        } catch {
+            XCTFail("Failed for unknown reason: \(error).")
+        }
+    }
+    
+    func testJSONDecodableExtensionOnInt() {
+        let four = 4
+        let fourJSON: JSON = 4
+        let fourPointZeroJSON: JSON = 4.0
+        
+        do {
+            let decodedFour = try Int(json: fourJSON)
+            let decodedFourPointZero = try Int(json: fourPointZeroJSON)
+            XCTAssertEqual(decodedFour, four, "`four` and 4 should be equal.")
+            XCTAssertEqual(decodedFourPointZero, four, "`decodedFourPointZero` and `four` should be equal.")
+        } catch {
+            XCTFail("Should be able to instantiate an `Int` with `JSON`: \(error).")
+        }
+        
+        do {
+            _ = try Int(json: "bad")
+            XCTFail("Should not be able to instantiate `Int` with `String` `JSON`.")
+        } catch JSON.Error.valueNotConvertible(let type) {
+            XCTAssert(true, "\(type) should not be covertible from 'bad' `String`.")
+        } catch {
+            XCTFail("Failed for unknown reason: \(error).")
+        }
+    }
+    
+    func testJSONDecodableExtensionOnString() {
+        let matt = "matt"
+        let stringJSON: JSON = "matt"
+        
+        do {
+            let decodedString = try String(json: stringJSON)
+            XCTAssertEqual(decodedString, matt, "`decodedString` and `matt` should be equal.")
+        } catch {
+            XCTFail("Should be able to instantiate a `String` with `JSON`: \(error).")
+        }
+        
+        do {
+            let four = try String(json: 4)
+            XCTAssertEqual(four, "4", "`four` and `4` should be equal.")
+        } catch JSON.Error.valueNotConvertible(let type) {
+            XCTAssert(true, "\(type) should be covertible from `Int.")
+        } catch {
+            XCTFail("Failed for unknown reason: \(error).")
+        }
+        
+        do {
+            let twoAndHalf = try String(json: 2.5)
+            XCTAssertEqual(twoAndHalf, "2.5", "`twoAndHalf` and `2.5` should be equal.")
+        } catch JSON.Error.valueNotConvertible(let type) {
+            XCTAssert(true, "\(type) should be covertible from `Double.")
+        } catch {
+            XCTFail("Failed for unknown reason: \(error).")
+        }
+        
+        do {
+            let positive = try String(json: true)
+            XCTAssertEqual(positive, "true", "`positive` and `true` should be equal.")
+        } catch JSON.Error.valueNotConvertible(let type) {
+            XCTAssert(true, "\(type) should be covertible from `Bool.")
+        } catch {
+            XCTFail("Failed for unknown reason: \(error).")
+        }
+    }
+    
+    func testJSONDecodableExtensionOnBool() {
+        let tru = true
+        let boolJSON: JSON = true
+        
+        do {
+            let decodedBool = try Bool(json: boolJSON)
+            XCTAssertEqual(decodedBool, tru, "`decodedBool` and `tru` should be equal.")
+        } catch {
+            XCTFail("Should be able to instantiate a `Bool` with `JSON`: \(error).")
+        }
+        
+        do {
+            _ = try Bool(json: "bad")
+            XCTFail("Should not be able to instantiate `Bool` with `String` `JSON`.")
+        } catch JSON.Error.valueNotConvertible(let type) {
+            XCTAssert(true, "\(type) should not be covertible from 'bad' string.")
+        } catch {
+            XCTFail("Failed for unknown reason: \(error).")
+        }
+    }
+    
+    func testThatJSONBoolIsDecodable() {
+        let JSONTrue: JSON = true
+        do {
+            let decodedTrue = try JSONTrue.getBool()
+            XCTAssertTrue(decodedTrue, "`JSONTrue` should decode to `true`.")
+        } catch {
+            XCTFail("`JSONTrue` should decode to `true`.")
+        }
+    }
+    
+    func testThatJSONArrayIsDecodable() {
+        let JSONArray: JSON = [1,2,3,4]
+        
+        do {
+            let decodedArray = try JSONArray.getArray()
+            XCTAssertEqual(decodedArray, [1,2,3,4], "`decodedArray` should match.")
+        } catch {
+            XCTFail("`decodedArray should be [1,2,3,4]")
+        }
+        
+        let badJSONArray: JSON = "bad"
+        do {
+            _ = try badJSONArray.getArray()
+            XCTFail("array should not exist.")
+        } catch JSON.Error.valueNotConvertible(let type) {
+            XCTAssert(true, "\(type) should not be convertible to `[JSON]`")
+        } catch {
+            XCTFail("Failed for unknown reason: \(error).")
+        }
+    }
+    
+    func testThatJSONDictionaryIsDecodable() {
+        let JSONDictionary: JSON = ["Matt": 32]
+        
+        do {
+            let decodedJSONDictionary = try JSONDictionary.getDictionary()
+            XCTAssertEqual(decodedJSONDictionary, ["Matt": 32], "`decodedJSONDictionary` should equal `[Matt: 32]`.")
+        } catch {
+            XCTFail("`decodedJSONDictionary` should equal `[Matt: 32]`.")
+        }
+        
+        let badJSONDictionary: JSON = 4
+        do {
+            _ = try badJSONDictionary.getDictionary()
+            XCTFail("There should be no dictionary.")
+        } catch JSON.Error.valueNotConvertible(let type) {
+            XCTAssertTrue(true, "\(type) shold not be convertible to `[String: JSON]`.")
+        } catch {
+            XCTFail("Failed for unknown reason: \(error).")
+        }
+    }
+    
+    func testThatArrayOfCanReturnArrayOfJSONDecodable() {
+        let oneTwoThreeJSON: JSON = [1,2,3]
+        
+        do {
+            let decodedOneTwoThree = try oneTwoThreeJSON.decodedArray(type: Swift.Int)
+            XCTAssertEqual(decodedOneTwoThree, [1,2,3], "`decodedOneTwoThree` should be equal to `[1,2,3]`.")
+        } catch {
+            XCTFail("`decodedOneTwoThree` should be equal to `[1,2,3]`.")
+        }
+    }
+    
+    func testThatDictionaryOfCanReturnDictionaryOfJSONDecodable() {
+        let oneTwoThreeJSON: JSON = ["one": 1, "two": 2, "three": 3]
+        
+        do {
+            let decodedOneTwoThree = try oneTwoThreeJSON.decodedDictionary(type: Swift.Int)
+            XCTAssertEqual(decodedOneTwoThree, ["one": 1, "two": 2, "three": 3], "`decodedOneTwoThree` should be equal to `[\"one\": 1, \"two\": 2, \"three\": 3]`.")
+        } catch {
+            XCTFail("`decodedOneTwoThree` should be equal to `[\"one\": 1, \"two\": 2, \"three\": 3]`.")
+        }
+    }
+    
+    func testThatNullIsDecodedToNilWhenRequestedAtTopLevel() {
+        let JSONDictionary: JSON = ["key": .null]
+        
+        do {
+            let value: Int? = try JSONDictionary.getInt(at: "key", alongPath: .NullBecomesNil)
+            XCTAssertEqual(value, nil)
+        } catch {
+            XCTFail("Should have retrieved nil for key `key` in `JSONDictionary` when specifying `ifNull` to be `true`.")
+        }
+    }
+    
+    func testThatAttemptingToDecodeNullThrowsWhenRequestedAtTopLevel() {
+        let JSONDictionary: JSON = ["key": .null]
+        
+        do {
+            let _: Int? = try JSONDictionary.getInt(at: "key")
+            XCTFail("Should have thrown an error when attempting to retrieve a value for key `key` in `JSONDictionary` when not specifying `ifNull` to be `true`.")
+        } catch let JSON.Error.valueNotConvertible(_, to) where to == Int.self {
+            return
+        } catch {
+            XCTFail("An unexpected exception was thrown.")
+        }
+        
+    }
+    
+}
+
+extension PersonClass: Equatable {}
+
+public func ==(lhs: PersonClass, rhs: PersonClass) -> Bool {
+    return (lhs.name == rhs.name) &&
+        (lhs.age == rhs.age) &&
+        (lhs.spouse == rhs.spouse)
+}

--- a/Tests/Person.swift
+++ b/Tests/Person.swift
@@ -42,3 +42,41 @@ extension Person: JSONEncodable {
         return .dictionary(["name": .string(name), "age": .int(age), "eyeColor": eyeColor.toJSON(), "spouse": .bool(spouse)])
     }
 }
+
+public final class PersonClass: CustomStringConvertible {
+    public enum EyeColor: String {
+        case Brown = "brown"
+        case Blue = "blue"
+        case Green = "green"
+    }
+    
+    public let name: String
+    public var age: Int
+    public let eyeColor: EyeColor
+    public let spouse: Bool
+    
+    init(name: String, age: Int, eyeColor: EyeColor, spouse: Bool) {
+        self.name = name
+        self.age = age
+        self.eyeColor = eyeColor
+        self.spouse = spouse
+    }
+    
+    public var description: String {
+        return "Name: \(name), age: \(age), married: \(spouse)"
+    }
+}
+
+extension PersonClass.EyeColor: JSONDecodable {}
+extension PersonClass.EyeColor: JSONEncodable {}
+
+extension PersonClass: JSONStaticDecodable {
+    
+    public static func fromJSON(json value: JSON) throws -> PersonClass {
+        let name = try value.getString(at: "name")
+        let age = try value.getInt(at: "age")
+        let eyeColor: EyeColor = try value.decode(at: "eyeColor")
+        let spouse = try value.getBool(at: "spouse")
+        return PersonClass(name: name, age: age, eyeColor: eyeColor, spouse: spouse)
+    }
+}


### PR DESCRIPTION
Swift won't let use JSONDecodable with extension on classes, added protocol can work around this issue.

Limitations: only works on final class