### PR TITLE
Fixing test testThatParserFailsWhenIncompleteDataIsPresent

### DIFF
--- a/Tests/JSONParserTests.swift
+++ b/Tests/JSONParserTests.swift
@@ -151,7 +151,7 @@ class JSONParserTests: XCTestCase {
     func testThatParserFailsWhenIncompleteDataIsPresent() {
         for s in [" ", "[0,", "{\"\":"] {
             do {
-                let value = try JSONParser.parse(" ")
+                let value = try JSONParser.parse(s)
                 XCTFail("Unexpectedly parsed \(s) as \(value)")
             } catch JSONParser.Error.endOfStreamUnexpected {
                 // expected error - do nothing


### PR DESCRIPTION
Was previously not iterating over test cases and instead using hard-coded string `" "` to test `JSONParser.parse`