### PR TITLE
Do not crash when string ends in backslash

### DIFF
--- a/Sources/JSONParser.swift
+++ b/Sources/JSONParser.swift
@@ -237,6 +237,7 @@ public struct JSONParser {
             switch input[loc] {
             case Literal.BACKSLASH:
                 loc = (loc + 1)
+                if loc >= input.count { continue }
                 switch input[loc] {
                 case Literal.DOUBLE_QUOTE: stringDecodingBuffer.append(Literal.DOUBLE_QUOTE)
                 case Literal.BACKSLASH:    stringDecodingBuffer.append(Literal.BACKSLASH)

--- a/Sources/JSONParser.swift
+++ b/Sources/JSONParser.swift
@@ -237,7 +237,7 @@ public struct JSONParser {
             switch input[loc] {
             case Literal.BACKSLASH:
                 loc = (loc + 1)
-                if loc >= input.count { continue }
+                guard loc < input.count else { continue }
                 switch input[loc] {
                 case Literal.DOUBLE_QUOTE: stringDecodingBuffer.append(Literal.DOUBLE_QUOTE)
                 case Literal.BACKSLASH:    stringDecodingBuffer.append(Literal.BACKSLASH)

--- a/Tests/FreddyTests/JSONParserTests.swift
+++ b/Tests/FreddyTests/JSONParserTests.swift
@@ -482,4 +482,15 @@ class JSONParserTests: XCTestCase {
             }
         }
     }
+
+    func testThatParserRejectsStringEndingInBackslash() {
+        let invalidJSONString = "[\"\\"
+        do {
+            _ = try JSONParser.parse(invalidJSONString)
+        } catch JSONParser.Error.endOfStreamUnexpected {
+            // do nothing - this is the expected error
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
 }


### PR DESCRIPTION
This is essentially #216, but with the merge conflict resolved and making a slight stylistic tweak to the check.

