### PR TITLE
Fix bug where long Float numbers are parsed as JSON.String instead of JSON.Double

### DIFF
--- a/Sources/JSONParser.swift
+++ b/Sources/JSONParser.swift
@@ -588,7 +588,15 @@ public struct JSONParser {
                 }
 
                 loc = parser.loc
-                return .String(string)
+                
+                // fix for the fact that we may have overflowed while parsing a floating point number - 
+                // try parsing the full string again.
+                if let dbl = Double(string) {
+                    return .Double(dbl)
+                }
+                else {
+                    return .String(string)                }
+
             }
         }
     }


### PR DESCRIPTION
The bug occurs on 32-bit platforms. This is because the parser treats numbers in the JSON data as Integers until encountering the decimal point, and using a `Int` to incrementally store them; on 32-bit platforms `Int` is 32-bit and thus it's easy to overflow while parsing a long floating point number. The current behavior is then to parse such numbers as JSON.String.

This patch fixes it in a quick-and-dirty manner by simply doing a final pass at the end to try and parse the string containing the number as a double in such a case.

