### PR TITLE
Improvements for working with optionals

### DIFF
--- a/Freddy.xcodeproj/project.pbxproj
+++ b/Freddy.xcodeproj/project.pbxproj
@@ -79,6 +79,13 @@
 		DB6ADFA91C2362E000D77BF1 /* JSONSubscripting.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB6ADF8F1C2362E000D77BF1 /* JSONSubscripting.swift */; };
 		DB6ADFAA1C2362E000D77BF1 /* JSONSubscripting.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB6ADF8F1C2362E000D77BF1 /* JSONSubscripting.swift */; };
 		DB6ADFAB1C2362E000D77BF1 /* JSONSubscripting.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB6ADF8F1C2362E000D77BF1 /* JSONSubscripting.swift */; };
+		DC6D0C741E4423AC0098D123 /* JSONOptional.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC6D0C731E4423AC0098D123 /* JSONOptional.swift */; };
+		DC6D0C751E44249C0098D123 /* JSONOptional.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC6D0C731E4423AC0098D123 /* JSONOptional.swift */; };
+		DC6D0C761E44249D0098D123 /* JSONOptional.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC6D0C731E4423AC0098D123 /* JSONOptional.swift */; };
+		DC6D0C771E44249D0098D123 /* JSONOptional.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC6D0C731E4423AC0098D123 /* JSONOptional.swift */; };
+		DC6D0C791E4424D40098D123 /* JSONOptionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC6D0C781E4424D40098D123 /* JSONOptionalTests.swift */; };
+		DC6D0C7A1E4424D80098D123 /* JSONOptionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC6D0C781E4424D40098D123 /* JSONOptionalTests.swift */; };
+		DC6D0C7B1E4424D90098D123 /* JSONOptionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC6D0C781E4424D40098D123 /* JSONOptionalTests.swift */; };
 		E43B67DB1C59598700ACE390 /* JSONEncodingDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43B67DA1C59598700ACE390 /* JSONEncodingDetector.swift */; };
 		E43B67DC1C59598700ACE390 /* JSONEncodingDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43B67DA1C59598700ACE390 /* JSONEncodingDetector.swift */; };
 		E43B67DD1C59598700ACE390 /* JSONEncodingDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43B67DA1C59598700ACE390 /* JSONEncodingDetector.swift */; };
@@ -144,6 +151,8 @@
 		DB6ADF8C1C2362E000D77BF1 /* JSONParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONParser.swift; sourceTree = "<group>"; };
 		DB6ADF8D1C2362E000D77BF1 /* JSONParsing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONParsing.swift; sourceTree = "<group>"; };
 		DB6ADF8F1C2362E000D77BF1 /* JSONSubscripting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONSubscripting.swift; sourceTree = "<group>"; };
+		DC6D0C731E4423AC0098D123 /* JSONOptional.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONOptional.swift; sourceTree = "<group>"; };
+		DC6D0C781E4424D40098D123 /* JSONOptionalTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = JSONOptionalTests.swift; path = FreddyTests/JSONOptionalTests.swift; sourceTree = "<group>"; };
 		E43B67DA1C59598700ACE390 /* JSONEncodingDetector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONEncodingDetector.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -235,6 +244,7 @@
 				DB6ADF8A1C2362E000D77BF1 /* JSONDecodable.swift */,
 				1C67C7251C3B2446003D5A05 /* JSONEncodable.swift */,
 				DB6ADF8B1C2362E000D77BF1 /* JSONLiteralConvertible.swift */,
+				DC6D0C731E4423AC0098D123 /* JSONOptional.swift */,
 				DB6ADF8C1C2362E000D77BF1 /* JSONParser.swift */,
 				DB6ADF8D1C2362E000D77BF1 /* JSONParsing.swift */,
 				3F70EA921C6D0D2B00972CEB /* JSONSerializing.swift */,
@@ -253,6 +263,7 @@
 				52E130C01DD536D8008A5396 /* JSONDecodableTests.swift */,
 				52E130C11DD536D8008A5396 /* JSONEncodableTests.swift */,
 				52E130C21DD536D8008A5396 /* JSONEncodingDetectorTests.swift */,
+				DC6D0C781E4424D40098D123 /* JSONOptionalTests.swift */,
 				52E130C31DD536D8008A5396 /* JSONParserTests.swift */,
 				52E130C41DD536D8008A5396 /* JSONSerializingTests.swift */,
 				52E130C51DD536D8008A5396 /* JSONSubscriptingTests.swift */,
@@ -576,6 +587,7 @@
 				3F70EA941C6D0D3000972CEB /* JSONSerializing.swift in Sources */,
 				DB6ADF911C2362E000D77BF1 /* JSON.swift in Sources */,
 				DB6ADFA91C2362E000D77BF1 /* JSONSubscripting.swift in Sources */,
+				DC6D0C751E44249C0098D123 /* JSONOptional.swift in Sources */,
 				DB6ADFA11C2362E000D77BF1 /* JSONParsing.swift in Sources */,
 				DB6ADF991C2362E000D77BF1 /* JSONLiteralConvertible.swift in Sources */,
 				1C67C7271C3B27DA003D5A05 /* JSONEncodable.swift in Sources */,
@@ -598,6 +610,7 @@
 				52E130ED1DD53791008A5396 /* Person.swift in Sources */,
 				52E130DB1DD53708008A5396 /* JSONEncodableTests.swift in Sources */,
 				52E130E01DD53708008A5396 /* JSONTests.swift in Sources */,
+				DC6D0C7A1E4424D80098D123 /* JSONOptionalTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -608,6 +621,7 @@
 				3F70EA931C6D0D2B00972CEB /* JSONSerializing.swift in Sources */,
 				DB6ADF901C2362E000D77BF1 /* JSON.swift in Sources */,
 				DB6ADFA81C2362E000D77BF1 /* JSONSubscripting.swift in Sources */,
+				DC6D0C741E4423AC0098D123 /* JSONOptional.swift in Sources */,
 				DB6ADFA01C2362E000D77BF1 /* JSONParsing.swift in Sources */,
 				DB6ADF981C2362E000D77BF1 /* JSONLiteralConvertible.swift in Sources */,
 				1C67C7261C3B2446003D5A05 /* JSONEncodable.swift in Sources */,
@@ -630,6 +644,7 @@
 				52E130EA1DD53790008A5396 /* Person.swift in Sources */,
 				52E130D41DD53707008A5396 /* JSONEncodableTests.swift in Sources */,
 				52E130D91DD53707008A5396 /* JSONTests.swift in Sources */,
+				DC6D0C791E4424D40098D123 /* JSONOptionalTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -640,6 +655,7 @@
 				3F70EA951C6D0D3100972CEB /* JSONSerializing.swift in Sources */,
 				DB6ADF921C2362E000D77BF1 /* JSON.swift in Sources */,
 				DB6ADFAA1C2362E000D77BF1 /* JSONSubscripting.swift in Sources */,
+				DC6D0C761E44249D0098D123 /* JSONOptional.swift in Sources */,
 				DB6ADFA21C2362E000D77BF1 /* JSONParsing.swift in Sources */,
 				DB6ADF9A1C2362E000D77BF1 /* JSONLiteralConvertible.swift in Sources */,
 				1C67C7281C3B27DC003D5A05 /* JSONEncodable.swift in Sources */,
@@ -662,6 +678,7 @@
 				52E130F01DD53792008A5396 /* Person.swift in Sources */,
 				52E130E21DD53709008A5396 /* JSONEncodableTests.swift in Sources */,
 				52E130E71DD53709008A5396 /* JSONTests.swift in Sources */,
+				DC6D0C7B1E4424D90098D123 /* JSONOptionalTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -672,6 +689,7 @@
 				3F70EA961C6D0D3200972CEB /* JSONSerializing.swift in Sources */,
 				DB6ADF931C2362E000D77BF1 /* JSON.swift in Sources */,
 				DB6ADFAB1C2362E000D77BF1 /* JSONSubscripting.swift in Sources */,
+				DC6D0C771E44249D0098D123 /* JSONOptional.swift in Sources */,
 				DB6ADFA31C2362E000D77BF1 /* JSONParsing.swift in Sources */,
 				DB6ADF9B1C2362E000D77BF1 /* JSONLiteralConvertible.swift in Sources */,
 				1C67C7291C3B27DD003D5A05 /* JSONEncodable.swift in Sources */,

--- a/Sources/JSONOptional.swift
+++ b/Sources/JSONOptional.swift
@@ -1,0 +1,61 @@
+//
+//  JSONOptional.swift
+//  Freddy
+//
+//  Created by David House on 2/2/17.
+//  Copyright © 2017 Big Nerd Ranch. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - OptionalLiteralConvertible
+extension JSON {
+
+    /// Create an instance from an Optional Double into either
+    /// a .double or .null
+    public init(_ optional: Double?) {
+        
+        guard let optional = optional else {
+            self = .null
+            return
+        }
+        
+        self = .double(optional)
+    }
+
+    /// Create an instance from an Optional Int into either
+    /// a .int or .null
+    public init(_ optional: Int?) {
+        
+        guard let optional = optional else {
+            self = .null
+            return
+        }
+        
+        self = .int(optional)
+    }
+    
+    /// Create an instance from an Optional Bool into either
+    /// a .bool or .null
+    public init(_ optional: Bool?) {
+        
+        guard let optional = optional else {
+            self = .null
+            return
+        }
+        
+        self = .bool(optional)
+    }
+    
+    /// Create an instance from an Optional String into either
+    /// a .string or .null
+    public init(_ optional: String?) {
+        
+        guard let optional = optional else {
+            self = .null
+            return
+        }
+        
+        self = .string(optional)
+    }
+}

--- a/Sources/JSONSerializing.swift
+++ b/Sources/JSONSerializing.swift
@@ -24,7 +24,7 @@ extension JSON {
     /// - returns: A byte-stream containing the `JSON` ready for wire transfer.
     /// - throws: Errors that arise from `JSONSerialization`.
     /// - see: Foundation.JSONSerialization
-    public func serialize(options: SerializeOptions = SerializeOptions(rawValue: 0)) throws -> Data {
+    public func serialize(options: SerializeOptions = []) throws -> Data {
         return try JSONSerialization.data(withJSONObject: toJSONSerializationValue(options: options), options: [])
     }
     
@@ -32,7 +32,7 @@ extension JSON {
     /// - returns: A `String` containing the `JSON`.
     /// - throws: A `JSON.Error.StringSerializationError` or errors that arise from `JSONSerialization`.
     /// - see: Foundation.JSONSerialization
-    public func serializeString(options: SerializeOptions = SerializeOptions(rawValue: 0)) throws -> String {
+    public func serializeString(options: SerializeOptions = []) throws -> String {
         let data = try self.serialize(options: options)
         guard let json = String(data: data, encoding: String.Encoding.utf8) else {
             throw Error.stringSerializationError
@@ -42,7 +42,7 @@ extension JSON {
 
     /// A function to help with the serialization of `JSON`.
     /// - returns: An `Any` suitable for `JSONSerialization`'s use.
-    private func toJSONSerializationValue(options: SerializeOptions = SerializeOptions(rawValue: 0)) -> Any {
+    private func toJSONSerializationValue(options: SerializeOptions = []) -> Any {
         switch self {
         case .array(let jsonArray):
             return jsonArray.map { $0.toJSONSerializationValue() }

--- a/Sources/JSONSerializing.swift
+++ b/Sources/JSONSerializing.swift
@@ -5,14 +5,16 @@ import Foundation
 // MARK: - Serialize Options
 
 /// An `OptionSet` used to represent the different options available for serializing `JSON` with `null` values.
-/// * `.nullSkipsKey` - Skip keys with `null` values
+/// * `.nullSkipsKey` - Skip keys with `null` values so the key is not included
+/// in the serialized json
 public struct SerializeOptions: OptionSet {
     public let rawValue: Int
     public init(rawValue: Int) {
         self.rawValue = rawValue
     }
     
-    /// Skip keys with `null` values
+    /// Skip keys with `null` values so the key is not included
+    /// in the serialized json
     public static let nullSkipsKey = SerializeOptions(rawValue: 1 << 0)
 }
 
@@ -21,6 +23,7 @@ public struct SerializeOptions: OptionSet {
 extension JSON {
 
     /// Attempt to serialize `JSON` into an `Data`.
+    /// - parameter options: SerializeOptions that control what should be done with keys that have values that are `null` when serializing the JSON
     /// - returns: A byte-stream containing the `JSON` ready for wire transfer.
     /// - throws: Errors that arise from `JSONSerialization`.
     /// - see: Foundation.JSONSerialization
@@ -29,6 +32,7 @@ extension JSON {
     }
     
     /// Attempt to serialize `JSON` into a `String`.
+    /// - parameter options: SerializeOptions that control what should be done with keys that have values that are `null` when serializing the JSON
     /// - returns: A `String` containing the `JSON`.
     /// - throws: A `JSON.Error.StringSerializationError` or errors that arise from `JSONSerialization`.
     /// - see: Foundation.JSONSerialization
@@ -41,6 +45,7 @@ extension JSON {
     }
 
     /// A function to help with the serialization of `JSON`.
+    /// - parameter options: SerializeOptions that control what should be done with keys that have values that are `null` when serializing the JSON
     /// - returns: An `Any` suitable for `JSONSerialization`'s use.
     private func toJSONSerializationValue(options: SerializeOptions = []) -> Any {
         switch self {

--- a/Sources/JSONSerializing.swift
+++ b/Sources/JSONSerializing.swift
@@ -2,6 +2,20 @@
 
 import Foundation
 
+// MARK: - Serialize Options
+
+/// An `OptionSet` used to represent the different options available for serializing `JSON` with `null` values.
+/// * `.nullSkipsKey` - Skip keys with `null` values
+public struct SerializeOptions: OptionSet {
+    public let rawValue: Int
+    public init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+    
+    /// Skip keys with `null` values
+    public static let nullSkipsKey = SerializeOptions(rawValue: 1 << 0)
+}
+
 // MARK: - Serialize JSON
 
 extension JSON {
@@ -10,16 +24,16 @@ extension JSON {
     /// - returns: A byte-stream containing the `JSON` ready for wire transfer.
     /// - throws: Errors that arise from `JSONSerialization`.
     /// - see: Foundation.JSONSerialization
-    public func serialize() throws -> Data {
-        return try JSONSerialization.data(withJSONObject: toJSONSerializationValue(), options: [])
+    public func serialize(options: SerializeOptions = SerializeOptions(rawValue: 0)) throws -> Data {
+        return try JSONSerialization.data(withJSONObject: toJSONSerializationValue(options: options), options: [])
     }
     
     /// Attempt to serialize `JSON` into a `String`.
     /// - returns: A `String` containing the `JSON`.
     /// - throws: A `JSON.Error.StringSerializationError` or errors that arise from `JSONSerialization`.
     /// - see: Foundation.JSONSerialization
-    public func serializeString() throws -> String {
-        let data = try self.serialize()
+    public func serializeString(options: SerializeOptions = SerializeOptions(rawValue: 0)) throws -> String {
+        let data = try self.serialize(options: options)
         guard let json = String(data: data, encoding: String.Encoding.utf8) else {
             throw Error.stringSerializationError
         }
@@ -28,14 +42,17 @@ extension JSON {
 
     /// A function to help with the serialization of `JSON`.
     /// - returns: An `Any` suitable for `JSONSerialization`'s use.
-    private func toJSONSerializationValue() -> Any {
+    private func toJSONSerializationValue(options: SerializeOptions = SerializeOptions(rawValue: 0)) -> Any {
         switch self {
         case .array(let jsonArray):
             return jsonArray.map { $0.toJSONSerializationValue() }
         case .dictionary(let jsonDictionary):
             var cocoaDictionary = Swift.Dictionary<Swift.String, Any>(minimumCapacity: jsonDictionary.count)
             for (key, json) in jsonDictionary {
-                cocoaDictionary[key] = json.toJSONSerializationValue()
+                
+                if json != .null || (json == .null && !options.contains(.nullSkipsKey)) {
+                    cocoaDictionary[key] = json.toJSONSerializationValue()
+                }
             }
             return cocoaDictionary
         case .string(let str):

--- a/Tests/FreddyTests/JSONOptionalTests.swift
+++ b/Tests/FreddyTests/JSONOptionalTests.swift
@@ -1,0 +1,49 @@
+//
+//  JSONOptionalTests.swift
+//  Freddy
+//
+//  Created by David House on 2/2/17.
+//  Copyright © 2017 Big Nerd Ranch. All rights reserved.
+//
+
+import XCTest
+import Freddy
+
+class JSONOptionalTests: XCTestCase {
+    
+    func testThatJSONCanBeCreatedFromDoubleOptionals() {
+        
+        let doubleWithValue: Double? = 123.45
+        let doubleWithoutValue: Double? = nil
+        
+        XCTAssertEqual(JSON(doubleWithValue), .double(123.45))
+        XCTAssertEqual(JSON(doubleWithoutValue), .null)
+    }
+    
+    func testThatJSONCanBeCreatedFromIntOptionals() {
+        
+        let intWithValue: Int? = 123
+        let intWithoutValue: Int? = nil
+        
+        XCTAssertEqual(JSON(intWithValue), .int(123))
+        XCTAssertEqual(JSON(intWithoutValue), .null)
+    }
+
+    func testThatJSONCanBeCreatedFromBoolOptionals() {
+        
+        let boolWithValue: Bool? = true
+        let boolWithoutValue: Bool? = nil
+        
+        XCTAssertEqual(JSON(boolWithValue), .bool(true))
+        XCTAssertEqual(JSON(boolWithoutValue), .null)
+    }
+    
+    func testThatJSONCanBeCreatedFromStringOptionals() {
+        
+        let stringWithValue: String? = "fred"
+        let stringWithoutValue: String? = nil
+        
+        XCTAssertEqual(JSON(stringWithValue), .string("fred"))
+        XCTAssertEqual(JSON(stringWithoutValue), .null)
+    }
+}

--- a/Tests/FreddyTests/JSONSerializingTests.swift
+++ b/Tests/FreddyTests/JSONSerializingTests.swift
@@ -66,8 +66,49 @@ class JSONSerializingTests: XCTestCase {
         let deserialized = JSON.dictionary(deserializedResult)
         XCTAssertEqual(json, deserialized, "Serialize/Deserialize succeed with Bools")
     }
-}
+    
+    func testThatSerializingCanSkipKeysWithNullValue() {
+        let json = JSON.dictionary([
+            "foo": .bool(true),
+            "bar": .bool(false),
+            "baz": .null,
+            ])
+        let string = try! json.serializeString(options: .nullSkipsKey)
+        XCTAssertFalse(string.contains("baz"))
+    }
 
+    func testThatSerializingUsingOptionalValuesIsPossible() {
+        
+        let phoneNumber: String? = "3332221111"
+        
+        let json = JSON.dictionary([
+            "firstName": .string("fred"),
+            "lastName": .string("flintstone"),
+            "phoneNumber": JSON(phoneNumber)
+            ])
+        let string = try! json.serializeString()
+        let deserializedResult = try! JSON(jsonString: string).getDictionary()
+        let deserialized = JSON.dictionary(deserializedResult)
+        XCTAssertEqual(json, deserialized, "Serialize/Deserialize succeed with Optional Values")
+        XCTAssertEqual(json["phoneNumber"], .string(phoneNumber!))
+    }
+
+    func testThatSerializingUsingOptionalNilValuesIsPossible() {
+        
+        let phoneNumber: String? = nil
+
+        let json = JSON.dictionary([
+                "firstName": .string("fred"),
+                "lastName": .string("flintstone"),
+                "phoneNumber": JSON(phoneNumber)
+            ])
+        let string = try! json.serializeString()
+        let deserializedResult = try! JSON(jsonString: string).getDictionary()
+        let deserialized = JSON.dictionary(deserializedResult)
+        XCTAssertEqual(json, deserialized, "Serialize/Deserialize succeed with Optional Values")
+        XCTAssertEqual(json["phoneNumber"], .null)
+    }
+}
 
 func dataFromFixture(_ filename: String) -> Data {
     let testBundle = Bundle(for: JSONSerializingTests.self)


### PR DESCRIPTION
Fixes #242 

This PR addresses two problems:

1) You can't create a JSON from an optional Double, Int, String or Bool. I think a reasonable approach is to turn an optional that is nil into the .null JSON type. This is done via an initializer for example:

```
let myString: String? = nil
let json = JSON(myString)   // becomes .null
```

2) When you are serializing a JSON dictionary with values that are .null, it would be nice to include an option that skips the key this null is associated with. Some systems prefer the key is not present in the JSON rather than `key = null`. Both are valid approaches, hence adding in an `options` parameter to request the skip key behavior.