### PR TITLE
Linux support

### DIFF
--- a/Sources/JSONParser.swift
+++ b/Sources/JSONParser.swift
@@ -7,6 +7,11 @@
 //
 
 import Foundation
+#if os(Linux)
+    import Glibc
+#else
+    import Darwin
+#endif
 
 private struct Literal {
     static let BACKSLASH     = UInt8(ascii: "\\")
@@ -591,7 +596,11 @@ public struct JSONParser {
     }
 
     private func detectingFloatingPointErrors<T>(start loc: Int, _ f: () throws -> T) throws -> T {
-        let flags = FE_UNDERFLOW | FE_OVERFLOW
+
+        // Explicit type declaration is necessary
+        // for compilation on Linux to succeed.
+        let flags: Int32 = FE_UNDERFLOW | FE_OVERFLOW
+        
         feclearexcept(flags)
         let value = try f()
         guard fetestexcept(flags) == 0 else {

--- a/Tests/FreddyTests/JSONDecodableTests.swift
+++ b/Tests/FreddyTests/JSONDecodableTests.swift
@@ -7,9 +7,27 @@
 //
 
 import XCTest
-import Freddy
+import Foundation
+@testable import Freddy
 
 class JSONDecodableTests: XCTestCase {
+    
+    static var allTests : [(String, (JSONDecodableTests) -> () throws -> Void)] {
+        return [
+            ("testThatJSONDecodableConformanceProducesInstance", testThatJSONDecodableConformanceProducesInstance),
+            ("testJSONDecodableExtensionOnDouble", testJSONDecodableExtensionOnDouble),
+            ("testJSONDecodableExtensionOnInt", testJSONDecodableExtensionOnInt),
+            ("testJSONDecodableExtensionOnString", testJSONDecodableExtensionOnString),
+            ("testJSONDecodableExtensionOnBool", testJSONDecodableExtensionOnBool),
+            ("testThatJSONBoolIsDecodable", testThatJSONBoolIsDecodable),
+            ("testThatJSONArrayIsDecodable", testThatJSONArrayIsDecodable),
+            ("testThatJSONDictionaryIsDecodable", testThatJSONDictionaryIsDecodable),
+            ("testThatArrayOfCanReturnArrayOfJSONDecodable", testThatArrayOfCanReturnArrayOfJSONDecodable),
+            ("testThatDictionaryOfCanReturnDictionaryOfJSONDecodable", testThatDictionaryOfCanReturnDictionaryOfJSONDecodable),
+            ("testThatNullIsDecodedToNilWhenRequestedAtTopLevel", testThatNullIsDecodedToNilWhenRequestedAtTopLevel),
+            ("testThatAttemptingToDecodeNullThrowsWhenRequestedAtTopLevel", testThatAttemptingToDecodeNullThrowsWhenRequestedAtTopLevel),
+        ]
+    }
 
     private var mattJSON: JSON!
     private var matt: Person!

--- a/Tests/FreddyTests/JSONEncodableTests.swift
+++ b/Tests/FreddyTests/JSONEncodableTests.swift
@@ -10,6 +10,19 @@ import XCTest
 @testable import Freddy
 
 class JSONEncodableTests: XCTestCase {
+    
+    static var allTests : [(String, (JSONEncodableTests) -> () throws -> Void)] {
+        return [
+            ("testThatJSONEncodableEncodesString", testThatJSONEncodableEncodesString),
+            ("testThatJSONEncodableEncodesBool", testThatJSONEncodableEncodesBool),
+            ("testThatJSONEncodableEncodesInt", testThatJSONEncodableEncodesInt),
+            ("testThatJSONEncodableEncodesDouble", testThatJSONEncodableEncodesDouble),
+            ("testThatJSONEncodableEncodesModelType", testThatJSONEncodableEncodesModelType),
+            ("testThatJSONEncodableEncodesArray", testThatJSONEncodableEncodesArray),
+            ("testThatJSONEncodableEncodesDictionary", testThatJSONEncodableEncodesDictionary),
+            ("testThatJSONEncodableEncodesArrayOfModels", testThatJSONEncodableEncodesArrayOfModels),
+        ]
+    }
 
     func testThatJSONEncodableEncodesString() {
         let matt = "Matt"

--- a/Tests/FreddyTests/JSONEncodingDetectorTests.swift
+++ b/Tests/FreddyTests/JSONEncodingDetectorTests.swift
@@ -7,9 +7,25 @@
 //
 
 import XCTest
+import Foundation
 @testable import Freddy
 
 class JSONEncodingDetectorTests: XCTestCase {
+    
+    static var allTests : [(String, (JSONEncodingDetectorTests) -> () throws -> Void)] {
+        return [
+            ("testUTF16LittleEndianDetection", testUTF16LittleEndianDetection),
+            ("testUTF16LittleEndianWithBOMDetection", testUTF16LittleEndianWithBOMDetection),
+            ("testUTF16BigEndianDetection", testUTF16BigEndianDetection),
+            ("testUTF16BigEndianWithBOMDetection", testUTF16BigEndianWithBOMDetection),
+            ("testUTF32LittleEndianDetection", testUTF32LittleEndianDetection),
+            ("testUTF32LittleEndianWithBOMDetection", testUTF32LittleEndianWithBOMDetection),
+            ("testUTF32BigEndianDetection", testUTF32BigEndianDetection),
+            ("testUTF32BigEndianWithBOMDetection", testUTF32BigEndianWithBOMDetection),
+            ("testUTF8Detection", testUTF8Detection),
+            ("testUTF8WithBOMDetection", testUTF8WithBOMDetection),
+        ]
+    }
 
     let fixtures = JSONEncodingUTFTestFixtures()
 

--- a/Tests/FreddyTests/JSONOptionalTests.swift
+++ b/Tests/FreddyTests/JSONOptionalTests.swift
@@ -7,9 +7,18 @@
 //
 
 import XCTest
-import Freddy
+@testable import Freddy
 
 class JSONOptionalTests: XCTestCase {
+    
+    static var allTests : [(String, (JSONOptionalTests) -> () throws -> Void)] {
+        return [
+            ("testThatJSONCanBeCreatedFromDoubleOptionals", testThatJSONCanBeCreatedFromDoubleOptionals),
+            ("testThatJSONCanBeCreatedFromIntOptionals", testThatJSONCanBeCreatedFromIntOptionals),
+            ("testThatJSONCanBeCreatedFromBoolOptionals", testThatJSONCanBeCreatedFromBoolOptionals),
+            ("testThatJSONCanBeCreatedFromStringOptionals", testThatJSONCanBeCreatedFromStringOptionals),
+        ]
+    }
     
     func testThatJSONCanBeCreatedFromDoubleOptionals() {
         

--- a/Tests/FreddyTests/JSONParserTests.swift
+++ b/Tests/FreddyTests/JSONParserTests.swift
@@ -7,7 +7,12 @@
 //
 
 import XCTest
-import Freddy
+import Foundation
+#if os(Linux)
+    // Can't seem to find this value in Glibc.
+    let DBL_EPSILON = 2.2204460492503131e-16
+#endif
+@testable import Freddy
 
 private func ==(lhs: JSONParser.Error, rhs: JSONParser.Error) -> Bool {
     switch (lhs, rhs) {
@@ -43,6 +48,44 @@ private func ==(lhs: JSONParser.Error, rhs: JSONParser.Error) -> Bool {
 }
 
 class JSONParserTests: XCTestCase {
+    
+    static var allTests : [(String, (JSONParserTests) -> () throws -> Void)] {
+        return [
+            ("testThatParserThrowsAnErrorForAnEmptyData", testThatParserThrowsAnErrorForAnEmptyData),
+            ("testThatParserThrowsErrorForInsufficientData", testThatParserThrowsErrorForInsufficientData),
+            ("testThatParserCompletesWithSingleZero", testThatParserCompletesWithSingleZero),
+            ("testThatParserCompletesWithBOMAndSingleZero", testThatParserCompletesWithBOMAndSingleZero),
+            ("testThatParserUnderstandsNull", testThatParserUnderstandsNull),
+            ("testThatParserSkipsLeadingWhitespace", testThatParserSkipsLeadingWhitespace),
+            ("testThatParserAllowsTrailingWhitespace", testThatParserAllowsTrailingWhitespace),
+            ("testThatParserFailsWhenTrailingDataIsPresent", testThatParserFailsWhenTrailingDataIsPresent),
+            ("testThatParserUnderstandsTrue", testThatParserUnderstandsTrue),
+            ("testThatParserUnderstandsFalse", testThatParserUnderstandsFalse),
+            ("testThatParserUnderstandsStringsWithoutEscapes", testThatParserUnderstandsStringsWithoutEscapes),
+            ("testThatParserUnderstandsStringsWithEscapedCharacters", testThatParserUnderstandsStringsWithEscapedCharacters),
+            ("testThatParserUnderstandsStringsWithEscapedUnicode", testThatParserUnderstandsStringsWithEscapedUnicode),
+            ("testThatParserFailsWhenIncompleteDataIsPresent", testThatParserFailsWhenIncompleteDataIsPresent),
+            ("testThatParserUnderstandsNumbers", testThatParserUnderstandsNumbers),
+            ("testThatParserRejectsInvalidNumbers", testThatParserRejectsInvalidNumbers),
+            ("testParserHandlingOfNumericOverflow", testParserHandlingOfNumericOverflow),
+            ("testStringFloatingPointCanBeInt", testStringFloatingPointCanBeInt),
+            ("testOverflowingIntResultsInStringWithNSJSONSerializationParser", testOverflowingIntResultsInStringWithNSJSONSerializationParser),
+            ("testOverflowingIntResultsInStringWithFreddyParser", testOverflowingIntResultsInStringWithFreddyParser),
+            ("testOverflowingInt32ResultsInIntWhenAppropriateWithFreddyParser", testOverflowingInt32ResultsInIntWhenAppropriateWithFreddyParser),
+            ("testLargeIntResultsInStringOrIntWithFreddyParser", testLargeIntResultsInStringOrIntWithFreddyParser),
+            ("testReturnsNilWhenDoubleValueExceedingIntMaxIsAccessedAsInt", testReturnsNilWhenDoubleValueExceedingIntMaxIsAccessedAsInt),
+            ("testThatParserUnderstandsEmptyArrays", testThatParserUnderstandsEmptyArrays),
+            ("testThatParserUnderstandsSingleItemArrays", testThatParserUnderstandsSingleItemArrays),
+            ("testThatParserUnderstandsMultipleItemArrays", testThatParserUnderstandsMultipleItemArrays),
+            ("testThatParserUnderstandsEmptyObjects", testThatParserUnderstandsEmptyObjects),
+            ("testThatParserUnderstandsSingleItemObjects", testThatParserUnderstandsSingleItemObjects),
+            ("testThatParserUnderstandsMultipleItemObjects", testThatParserUnderstandsMultipleItemObjects),
+            ("testThatParserFailsForUnsupportedEncodings", testThatParserFailsForUnsupportedEncodings),
+            ("testThatParserAcceptsUTF16SurrogatePairs", testThatParserAcceptsUTF16SurrogatePairs),
+            ("testThatParserRejectsInvalidUTF16SurrogatePairs", testThatParserRejectsInvalidUTF16SurrogatePairs),
+            ("testThatParserRejectsStringEndingInBackslash", testThatParserRejectsStringEndingInBackslash),
+        ]
+    }
 
     func testThatParserThrowsAnErrorForAnEmptyData() {
         

--- a/Tests/FreddyTests/JSONSerializingTests.swift
+++ b/Tests/FreddyTests/JSONSerializingTests.swift
@@ -1,9 +1,27 @@
 // Copyright (C) 2016 Big Nerd Ranch, Inc. Licensed under the MIT license WITHOUT ANY WARRANTY.
 
 import XCTest
-import Freddy
+import Foundation
+@testable import Freddy
 
 class JSONSerializingTests: XCTestCase {
+    
+    static var allTests : [(String, (JSONSerializingTests) -> () throws -> Void)] {
+        return [
+            ("testThatJSONCanBeSerializedToNSData", testThatJSONCanBeSerializedToNSData),
+            ("testThatJSONCanBeSerializedToString", testThatJSONCanBeSerializedToString),
+            ("testThatJSONDataIsEqual", testThatJSONDataIsEqual),
+            ("testThatJSONStringIsEqual", testThatJSONStringIsEqual),
+            ("testThatJSONDataSerializationMakesEqualJSON", testThatJSONDataSerializationMakesEqualJSON),
+            ("testThatJSONStringSerializationMakesEqualJSON", testThatJSONStringSerializationMakesEqualJSON),
+            ("testThatJSONSerializationHandlesBoolsCorrectly", testThatJSONSerializationHandlesBoolsCorrectly),
+            ("testThatJSONStringSerializationHandlesBoolsCorrectly", testThatJSONStringSerializationHandlesBoolsCorrectly),
+            ("testThatSerializingCanSkipKeysWithNullValue", testThatSerializingCanSkipKeysWithNullValue),
+            ("testThatSerializingUsingOptionalValuesIsPossible", testThatSerializingUsingOptionalValuesIsPossible),
+            ("testThatSerializingUsingOptionalNilValuesIsPossible", testThatSerializingUsingOptionalNilValuesIsPossible),
+        ]
+    }
+
     let json = JSONFromFixture("sample.JSON")
     let noWhiteSpaceData = dataFromFixture("sampleNoWhiteSpace.JSON")
 

--- a/Tests/FreddyTests/JSONSubscriptingTests.swift
+++ b/Tests/FreddyTests/JSONSubscriptingTests.swift
@@ -7,9 +7,53 @@
 //
 
 import XCTest
-import Freddy
+import Foundation
+@testable import Freddy
 
 class JSONSubscriptingTests: XCTestCase {
+    
+    static var allTests : [(String, (JSONSubscriptingTests) -> () throws -> Void)] {
+        return [
+            ("testThatArrayOfProducesResidents", testThatArrayOfProducesResidents),
+            ("testThatDictionaryOfProducesResidentsByName", testThatDictionaryOfProducesResidentsByName),
+            ("testNullOptionsDecodes", testNullOptionsDecodes),
+            ("testNullOptionsProducesOptionalForNotFoundWithArrayOf", testNullOptionsProducesOptionalForNotFoundWithArrayOf),
+            ("testNullOptionsProducesOptionalForNotFoundWithDictionaryOf", testNullOptionsProducesOptionalForNotFoundWithDictionaryOf),
+            ("testNullOptionsProducesOptionalForNullOrNotFoundWithArrayOf", testNullOptionsProducesOptionalForNullOrNotFoundWithArrayOf),
+            ("testNullOptionsProducesOptionalForNullOrNotFoundWithDictionaryOf", testNullOptionsProducesOptionalForNullOrNotFoundWithDictionaryOf),
+            ("testNullOptionsIndexOutOfBoundsProducesOptional", testNullOptionsIndexOutOfBoundsProducesOptional),
+            ("testArrayOfJSONIntAndNullCreatesOptionalWhenDetectNull", testArrayOfJSONIntAndNullCreatesOptionalWhenDetectNull),
+            ("testArrayProducesOptionalWhenNotFoundOrNull", testArrayProducesOptionalWhenNotFoundOrNull),
+            ("testDictionaryOfJSONIntAndNullCreatesOptionalWhenDetectNull", testDictionaryOfJSONIntAndNullCreatesOptionalWhenDetectNull),
+            ("testDictionaryProducesOptionalWhenNotFoundOrNull", testDictionaryProducesOptionalWhenNotFoundOrNull),
+            ("testDecodenullBecomesNilProducesOptional", testDecodenullBecomesNilProducesOptional),
+            ("testJSONDictionaryUnexpectedSubscript", testJSONDictionaryUnexpectedSubscript),
+            ("testJSONIndexSubscript", testJSONIndexSubscript),
+            ("testJSONKeySubscript", testJSONKeySubscript),
+            ("testDecodeOr", testDecodeOr),
+            ("testDoubleOr", testDoubleOr),
+            ("testStringOr", testStringOr),
+            ("testIntOr", testIntOr),
+            ("testBoolOr", testBoolOr),
+            ("testArrayOr", testArrayOr),
+            ("testArrayOfOr", testArrayOfOr),
+            ("testDictionaryOr", testDictionaryOr),
+            ("testDictionaryOfOr", testDictionaryOfOr),
+            ("testThatUnexpectedSubscriptIsThrown", testThatUnexpectedSubscriptIsThrown),
+            ("testMissingKeyOptionStillFailsIfNullEncountered", testMissingKeyOptionStillFailsIfNullEncountered),
+            ("testSubscriptingOptionsStillFailIfKeyIsMissing", testSubscriptingOptionsStillFailIfKeyIsMissing),
+//            ("testThatMapCanCreateArrayOfPeople", testThatMapCanCreateArrayOfPeople),
+//            ("testThatSubscriptingJSONWorksForTopLevelObject", testThatSubscriptingJSONWorksForTopLevelObject),
+//            ("testThatPathSubscriptingPerformsNesting", testThatPathSubscriptingPerformsNesting),
+//            ("testJSONSubscriptWithInt", testJSONSubscriptWithInt),
+//            ("testJSONErrorKeyNotFound", testJSONErrorKeyNotFound),
+//            ("testJSONErrorIndexOutOfBounds", testJSONErrorIndexOutOfBounds),
+//            ("testJSONErrorTypeNotConvertible", testJSONErrorTypeNotConvertible),
+//            ("testJSONErrorUnexpectedSubscript", testJSONErrorUnexpectedSubscript),
+            ("testThatOptionalSubscriptingIntoNullSucceeds", testThatOptionalSubscriptingIntoNullSucceeds),
+            ("testThatOptionalSubscriptingKeyNotFoundSucceeds", testThatOptionalSubscriptingKeyNotFoundSucceeds),
+        ]
+    }
     
     private var residentJSON: JSON!
     private var json: JSON!
@@ -35,25 +79,43 @@ class JSONSubscriptingTests: XCTestCase {
             ]
             ])
         
+        #if !os(Linux) // Bundle(for:) is NSNotImplemented
+        let sampleData: Data
         let testBundle = Bundle(for: JSONSubscriptingTests.self)
-        guard let data = testBundle.url(forResource: "sample", withExtension: "JSON").flatMap(NSData.init(contentsOf:)) else {
-            XCTFail("Could not read sample data from test bundle")
+        do {
+            guard let data = try testBundle.url(forResource: "sample", withExtension: "JSON").flatMap({ try Data(contentsOf: $0)} ) else {
+                XCTFail("Could not read sample data from test bundle")
+                return
+            }
+            
+            sampleData = data
+            
+        } catch {
+            XCTFail("Could not read sample data from test bundle: \(error)")
             return
         }
-        
+
         do {
-            self.json = try JSON(data: data as Data, usingParser: parser())
+            self.json = try JSON(data: sampleData, usingParser: parser())
         } catch {
             XCTFail("Could not parse sample JSON: \(error)")
             return
         }
         
-        guard let noWhiteSpaceData = testBundle.url(forResource: "sampleNoWhiteSpace", withExtension: "JSON").flatMap(NSData.init(contentsOf:)) else {
-            XCTFail("Could not read sample data (no whitespace) from test bundle")
+        do {
+            guard let noWhiteSpaceData = try testBundle.url(forResource: "sampleNoWhiteSpace", withExtension: "JSON").flatMap({ try Data(contentsOf: $0)} ) else {
+                XCTFail("Could not read sample data (no whitespace) from test bundle")
+                return
+            }
+            
+            self.noWhiteSpaceData = noWhiteSpaceData
+            
+        } catch {
+            XCTFail("Could not read sample data (no whitespace) from test bundle: \(error)")
             return
         }
-        
-        self.noWhiteSpaceData = noWhiteSpaceData as Data
+        #endif
+
     }
     
     func testThatArrayOfProducesResidents() {

--- a/Tests/FreddyTests/JSONTests.swift
+++ b/Tests/FreddyTests/JSONTests.swift
@@ -7,21 +7,41 @@
 //
 
 import XCTest
-import Freddy
+import Foundation
+@testable import Freddy
 
 class JSONTests: XCTestCase {
+    
+    static var allTests : [(String, (JSONTests) -> () throws -> Void)] {
+        return [
+//            ("testInitializingFromData", testInitializingFromData),
+//            ("DoNotRuntestInitializingFromEmptyData", DoNotRuntestInitializingFromEmptyData), // TODO: Do not run
+            ("testInitializingFromString", testInitializingFromString),
+//            ("DoNotRuntestInitializingFromEmptyString", DoNotRuntestInitializingFromEmptyString), // TODO: Do not run
+        ]
+    }
 
-    var sampleData:Data!
+    var sampleData: Data!
     
     override func setUp() {
         super.setUp()
         
-        let testBundle = Bundle(for: JSONSubscriptingTests.self)
-        guard let data = testBundle.url(forResource: "sample", withExtension: "JSON").flatMap(NSData.init(contentsOf:)) else {
-            XCTFail("Could not read sample data from test bundle")
+        #if !os(Linux) // Bundle(for:) is NSNotImplemented
+        let testBundle = Bundle(for: JSONTests.self)
+        do {
+            guard let data = try testBundle.url(forResource: "sample", withExtension: "JSON").flatMap({ try Data(contentsOf: $0)} ) else {
+                XCTFail("Could not read sample data from test bundle")
+                return
+            }
+            
+            sampleData = data
+            
+        } catch {
+            XCTFail("Could not read sample data from test bundle: \(error)")
             return
         }
-        sampleData = data as Data
+        #endif
+        
     }
     
     func testInitializingFromData() {

--- a/Tests/FreddyTests/JSONTypeTests.swift
+++ b/Tests/FreddyTests/JSONTypeTests.swift
@@ -7,9 +7,23 @@
 //
 
 import XCTest
-import Freddy
+@testable import Freddy
 
 class JSONTypeTests: XCTestCase {
+    
+    static var allTests : [(String, (JSONTypeTests) -> () throws -> Void)] {
+        return [
+            ("testCastInitializeArray", testCastInitializeArray),
+            ("testCastInitializeAnyCollection", testCastInitializeAnyCollection),
+            ("testCastInitializeDictionary", testCastInitializeDictionary),
+            ("testCastInitializeAnyDictionary", testCastInitializeAnyDictionary),
+            ("testCastInitializeDouble", testCastInitializeDouble),
+            ("testCastInitializeInt", testCastInitializeInt),
+            ("testCastInitializeString", testCastInitializeString),
+            ("testCastInitializeBool", testCastInitializeBool),
+            ("testLiteralConversion", testLiteralConversion),
+        ]
+    }
     
     func testCastInitializeArray() {
         let array: [JSON] = [1, 2, 3]

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,0 +1,14 @@
+import XCTest
+@testable import FreddyTests
+
+XCTMain([
+     testCase(JSONDecodableTests.allTests),
+     testCase(JSONEncodableTests.allTests),
+     testCase(JSONEncodingDetectorTests.allTests),
+     testCase(JSONOptionalTests.allTests),
+     testCase(JSONParserTests.allTests),
+//     testCase(JSONSerializingTests.allTests),
+     testCase(JSONSubscriptingTests.allTests),
+     testCase(JSONTests.allTests),
+     testCase(JSONTypeTests.allTests),
+])


### PR DESCRIPTION
I've made some changes, so that Freddy will build and work on Linux.
Tests can be run with `swift test` in the Freddy directory.

**What appears to work:**
Freddy (disclaimer: for my use) and 107 of its tests.

**What doesn't work:**
Tests that rely on [Bundle(for:)](https://github.com/apple/swift-corelibs-foundation/blob/master/Foundation/NSBundle.swift#L56), because it has yet to be implemented in Foundation. These include some of the JSONSubscriptingTests, JSONTests and all of the JSONSerializingTests. Note that the tests are (not necessarily) failing. They just won't run at the moment. For now, I've commented out these tests and added some conditional compilation statements to prevent the code from being reached on Linux. Of the 107 tests that run properly, only a single fails: 

`/project/Tests/FreddyTests/JSONParserTests.swift:333: error: JSONParserTests.testOverflowingIntResultsInStringWithNSJSONSerializationParser : XCTAssertEqual failed: ("nil") is not equal to ("Optional(1.8446744073709552e+19)") - as double`

I have yet to look for the culprit.