### PR TITLE
Compile under Swift 4

### DIFF
--- a/Freddy.xcodeproj/project.pbxproj
+++ b/Freddy.xcodeproj/project.pbxproj
@@ -49,6 +49,9 @@
 		52E130F11DD53792008A5396 /* sample.JSON in Resources */ = {isa = PBXBuildFile; fileRef = 52E130BA1DD536C3008A5396 /* sample.JSON */; };
 		52E130F21DD53792008A5396 /* sampleNoWhiteSpace.JSON in Resources */ = {isa = PBXBuildFile; fileRef = 52E130BB1DD536C3008A5396 /* sampleNoWhiteSpace.JSON */; };
 		601AE3D31EE1B39300617386 /* IntExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601AE3D21EE1B39300617386 /* IntExtensions.swift */; };
+		601AE3D41EE1C14400617386 /* IntExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601AE3D21EE1B39300617386 /* IntExtensions.swift */; };
+		601AE3D51EE1C14500617386 /* IntExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601AE3D21EE1B39300617386 /* IntExtensions.swift */; };
+		601AE3D61EE1C14500617386 /* IntExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601AE3D21EE1B39300617386 /* IntExtensions.swift */; };
 		DB6ADF231C23610B00D77BF1 /* Freddy.h in Headers */ = {isa = PBXBuildFile; fileRef = DB6ADF221C23610B00D77BF1 /* Freddy.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DB6ADF2A1C23610B00D77BF1 /* Freddy.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB6ADF1F1C23610B00D77BF1 /* Freddy.framework */; };
 		DB6ADF481C23612000D77BF1 /* Freddy.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB6ADF3E1C23612000D77BF1 /* Freddy.framework */; };
@@ -591,6 +594,7 @@
 				DB6ADF911C2362E000D77BF1 /* JSON.swift in Sources */,
 				DB6ADFA91C2362E000D77BF1 /* JSONSubscripting.swift in Sources */,
 				DC6D0C751E44249C0098D123 /* JSONOptional.swift in Sources */,
+				601AE3D41EE1C14400617386 /* IntExtensions.swift in Sources */,
 				DB6ADFA11C2362E000D77BF1 /* JSONParsing.swift in Sources */,
 				DB6ADF991C2362E000D77BF1 /* JSONLiteralConvertible.swift in Sources */,
 				1C67C7271C3B27DA003D5A05 /* JSONEncodable.swift in Sources */,
@@ -660,6 +664,7 @@
 				DB6ADF921C2362E000D77BF1 /* JSON.swift in Sources */,
 				DB6ADFAA1C2362E000D77BF1 /* JSONSubscripting.swift in Sources */,
 				DC6D0C761E44249D0098D123 /* JSONOptional.swift in Sources */,
+				601AE3D51EE1C14500617386 /* IntExtensions.swift in Sources */,
 				DB6ADFA21C2362E000D77BF1 /* JSONParsing.swift in Sources */,
 				DB6ADF9A1C2362E000D77BF1 /* JSONLiteralConvertible.swift in Sources */,
 				1C67C7281C3B27DC003D5A05 /* JSONEncodable.swift in Sources */,
@@ -694,6 +699,7 @@
 				DB6ADF931C2362E000D77BF1 /* JSON.swift in Sources */,
 				DB6ADFAB1C2362E000D77BF1 /* JSONSubscripting.swift in Sources */,
 				DC6D0C771E44249D0098D123 /* JSONOptional.swift in Sources */,
+				601AE3D61EE1C14500617386 /* IntExtensions.swift in Sources */,
 				DB6ADFA31C2362E000D77BF1 /* JSONParsing.swift in Sources */,
 				DB6ADF9B1C2362E000D77BF1 /* JSONLiteralConvertible.swift in Sources */,
 				1C67C7291C3B27DD003D5A05 /* JSONEncodable.swift in Sources */,

--- a/Freddy.xcodeproj/project.pbxproj
+++ b/Freddy.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		52E130F01DD53792008A5396 /* Person.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52E130B91DD536C3008A5396 /* Person.swift */; };
 		52E130F11DD53792008A5396 /* sample.JSON in Resources */ = {isa = PBXBuildFile; fileRef = 52E130BA1DD536C3008A5396 /* sample.JSON */; };
 		52E130F21DD53792008A5396 /* sampleNoWhiteSpace.JSON in Resources */ = {isa = PBXBuildFile; fileRef = 52E130BB1DD536C3008A5396 /* sampleNoWhiteSpace.JSON */; };
+		601AE3D31EE1B39300617386 /* IntExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601AE3D21EE1B39300617386 /* IntExtensions.swift */; };
 		DB6ADF231C23610B00D77BF1 /* Freddy.h in Headers */ = {isa = PBXBuildFile; fileRef = DB6ADF221C23610B00D77BF1 /* Freddy.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DB6ADF2A1C23610B00D77BF1 /* Freddy.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB6ADF1F1C23610B00D77BF1 /* Freddy.framework */; };
 		DB6ADF481C23612000D77BF1 /* Freddy.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB6ADF3E1C23612000D77BF1 /* Freddy.framework */; };
@@ -131,6 +132,7 @@
 		52E130C51DD536D8008A5396 /* JSONSubscriptingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = JSONSubscriptingTests.swift; path = FreddyTests/JSONSubscriptingTests.swift; sourceTree = "<group>"; };
 		52E130C61DD536D8008A5396 /* JSONTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = JSONTests.swift; path = FreddyTests/JSONTests.swift; sourceTree = "<group>"; };
 		52E130C71DD536D8008A5396 /* JSONTypeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = JSONTypeTests.swift; path = FreddyTests/JSONTypeTests.swift; sourceTree = "<group>"; };
+		601AE3D21EE1B39300617386 /* IntExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IntExtensions.swift; sourceTree = "<group>"; };
 		DB6ADF1F1C23610B00D77BF1 /* Freddy.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Freddy.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DB6ADF221C23610B00D77BF1 /* Freddy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Freddy.h; sourceTree = "<group>"; };
 		DB6ADF241C23610B00D77BF1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -250,6 +252,7 @@
 				3F70EA921C6D0D2B00972CEB /* JSONSerializing.swift */,
 				DB6ADF8F1C2362E000D77BF1 /* JSONSubscripting.swift */,
 				E43B67DA1C59598700ACE390 /* JSONEncodingDetector.swift */,
+				601AE3D21EE1B39300617386 /* IntExtensions.swift */,
 				DB6ADF241C23610B00D77BF1 /* Info.plist */,
 			);
 			name = Freddy;
@@ -622,6 +625,7 @@
 				DB6ADF901C2362E000D77BF1 /* JSON.swift in Sources */,
 				DB6ADFA81C2362E000D77BF1 /* JSONSubscripting.swift in Sources */,
 				DC6D0C741E4423AC0098D123 /* JSONOptional.swift in Sources */,
+				601AE3D31EE1B39300617386 /* IntExtensions.swift in Sources */,
 				DB6ADFA01C2362E000D77BF1 /* JSONParsing.swift in Sources */,
 				DB6ADF981C2362E000D77BF1 /* JSONLiteralConvertible.swift in Sources */,
 				1C67C7261C3B2446003D5A05 /* JSONEncodable.swift in Sources */,

--- a/Sources/IntExtensions.swift
+++ b/Sources/IntExtensions.swift
@@ -1,0 +1,37 @@
+//
+//  IntExtensions.swift
+//  Freddy
+//
+//  Created by Volodymyr  Gorbenko on 2/6/17.
+//  Copyright © 2017 Big Nerd Ranch. All rights reserved.
+//
+
+import Foundation
+
+#if swift(>=4.0)
+#else
+
+public enum ArithmeticOverflow {
+
+  public init(_ overflow: Bool) {
+    self = overflow ? .overflow : .none
+  }
+
+  case none
+  case overflow
+}
+
+extension Int {
+
+  func multipliedReportingOverflow(by other: Int) -> (partialValue: Int, overflow: ArithmeticOverflow) {
+    let (exponent, overflow) = Int.multiplyWithOverflow(self, other)
+    return (exponent, ArithmeticOverflow(overflow))
+  }
+
+  func addingReportingOverflow(_ other: Int) -> (partialValue: Int, overflow: ArithmeticOverflow) {
+    let (exponent, overflow) = Int.addWithOverflow(self, other)
+    return (exponent, ArithmeticOverflow(overflow))
+  }
+}
+
+#endif

--- a/Sources/JSONParser.swift
+++ b/Sources/JSONParser.swift
@@ -456,7 +456,6 @@ public struct JSONParser {
 
             case .preDecimalDigits:
                 try parser.parsePreDecimalDigits { c in
-                    #if swift(>=4.0)
                     guard case let (exponent, .none) = 10.multipliedReportingOverflow(by: value) else {
                         throw InternalError.numberOverflow(offset: parser.start)
                     }
@@ -464,15 +463,6 @@ public struct JSONParser {
                     guard case let (newValue, .none) = exponent.addingReportingOverflow(Int(c - Literal.zero)) else {
                         throw InternalError.numberOverflow(offset: parser.start)
                     }
-                    #else
-                    guard case let (exponent, false) = Int.multiplyWithOverflow(10, value) else {
-                        throw InternalError.numberOverflow(offset: parser.start)
-                    }
-                    
-                    guard case let (newValue, false) = Int.addWithOverflow(exponent, Int(c - Literal.zero)) else {
-                        throw InternalError.numberOverflow(offset: parser.start)
-                    }
-                    #endif
                     
                     value = newValue
                 }
@@ -490,15 +480,9 @@ public struct JSONParser {
             }
         }
 
-        #if swift(>=4.0)
         guard case let (signedValue, .none) = sign.rawValue.multipliedReportingOverflow(by: value) else {
             throw InternalError.numberOverflow(offset: parser.start)
         }
-        #else
-        guard case let (signedValue, false) = Int.multiplyWithOverflow(sign.rawValue, value) else {
-            throw InternalError.numberOverflow(offset: parser.start)
-        }
-        #endif
 
         loc = parser.loc
         return .int(signedValue)

--- a/Sources/JSONParser.swift
+++ b/Sources/JSONParser.swift
@@ -456,6 +456,15 @@ public struct JSONParser {
 
             case .preDecimalDigits:
                 try parser.parsePreDecimalDigits { c in
+                    #if swift(>=4.0)
+                    guard case let (exponent, .none) = 10.multipliedReportingOverflow(by: value) else {
+                        throw InternalError.numberOverflow(offset: parser.start)
+                    }
+                    
+                    guard case let (newValue, .none) = exponent.addingReportingOverflow(Int(c - Literal.zero)) else {
+                        throw InternalError.numberOverflow(offset: parser.start)
+                    }
+                    #else
                     guard case let (exponent, false) = Int.multiplyWithOverflow(10, value) else {
                         throw InternalError.numberOverflow(offset: parser.start)
                     }
@@ -463,6 +472,7 @@ public struct JSONParser {
                     guard case let (newValue, false) = Int.addWithOverflow(exponent, Int(c - Literal.zero)) else {
                         throw InternalError.numberOverflow(offset: parser.start)
                     }
+                    #endif
                     
                     value = newValue
                 }
@@ -480,9 +490,15 @@ public struct JSONParser {
             }
         }
 
+        #if swift(>=4.0)
+        guard case let (signedValue, .none) = sign.rawValue.multipliedReportingOverflow(by: value) else {
+            throw InternalError.numberOverflow(offset: parser.start)
+        }
+        #else
         guard case let (signedValue, false) = Int.multiplyWithOverflow(sign.rawValue, value) else {
             throw InternalError.numberOverflow(offset: parser.start)
         }
+        #endif
 
         loc = parser.loc
         return .int(signedValue)

--- a/Sources/JSONParsing.swift
+++ b/Sources/JSONParsing.swift
@@ -118,15 +118,9 @@ extension JSONSerialization: JSONParserType {
     /// - parameter jsonDict: The dictionary to transform into `JSON`.
     /// - returns: An instance of `JSON` matching the dictionary.
     private static func makeJSONDictionary(_ jsonDict: [Swift.String: Any]) -> JSON {
-        #if swift(>=4.0)
-        return JSON(jsonDict.lazy.map { arg in
-            (arg.key, makeJSON(with: arg.value))
+        return JSON(jsonDict.lazy.map { pair in
+            (pair.key, makeJSON(with: pair.value))
         })
-        #else
-        return JSON(jsonDict.lazy.map { (key, value) in
-            (key, makeJSON(with: value))
-        })
-        #endif
     }
 
 }

--- a/Sources/JSONParsing.swift
+++ b/Sources/JSONParsing.swift
@@ -118,9 +118,15 @@ extension JSONSerialization: JSONParserType {
     /// - parameter jsonDict: The dictionary to transform into `JSON`.
     /// - returns: An instance of `JSON` matching the dictionary.
     private static func makeJSONDictionary(_ jsonDict: [Swift.String: Any]) -> JSON {
+        #if swift(>=4.0)
+        return JSON(jsonDict.lazy.map { arg in
+            (arg.key, makeJSON(with: arg.value))
+        })
+        #else
         return JSON(jsonDict.lazy.map { (key, value) in
             (key, makeJSON(with: value))
         })
+        #endif
     }
 
 }

--- a/Tests/FreddyTests/JSONSubscriptingTests.swift
+++ b/Tests/FreddyTests/JSONSubscriptingTests.swift
@@ -69,7 +69,11 @@ class JSONSubscriptingTests: XCTestCase {
     func testThatDictionaryOfProducesResidentsByName() {
         do {
             let residentsByName = try residentJSON.decodedDictionary(at: "residentsByName", type: Resident.self)
+            #if swift(>=4.0)
+            let residentsNames = residentsByName.map { $0.value.name }
+            #else
             let residentsNames = residentsByName.map { $1.name }
+            #endif
             XCTAssertEqual(residentsNames.count, 3, "There should be 3 residents.")
         } catch {
             XCTFail("There should be no error: \(error).")

--- a/Tests/FreddyTests/JSONSubscriptingTests.swift
+++ b/Tests/FreddyTests/JSONSubscriptingTests.swift
@@ -69,11 +69,7 @@ class JSONSubscriptingTests: XCTestCase {
     func testThatDictionaryOfProducesResidentsByName() {
         do {
             let residentsByName = try residentJSON.decodedDictionary(at: "residentsByName", type: Resident.self)
-            #if swift(>=4.0)
             let residentsNames = residentsByName.map { $0.value.name }
-            #else
-            let residentsNames = residentsByName.map { $1.name }
-            #endif
             XCTAssertEqual(residentsNames.count, 3, "There should be 3 residents.")
         } catch {
             XCTFail("There should be no error: \(error).")

--- a/Tests/FreddyTests/JSONTypeTests.swift
+++ b/Tests/FreddyTests/JSONTypeTests.swift
@@ -34,9 +34,15 @@ class JSONTypeTests: XCTestCase {
 
     func testCastInitializeAnyDictionary() {
         let dictionary = ["foo": 1, "bar": 2, "baz": 3]
+        #if swift(>=4.0)
+        let pairCollection = dictionary.lazy.map { arg in
+            (arg.key, JSON(arg.value * 2))
+        }
+        #else
         let pairCollection = dictionary.lazy.map { (key, value) in
             (key, JSON(value * 2))
         }
+        #endif
         let expected: JSON = .dictionary(["foo": 2, "bar": 4, "baz": 6])
         let json = JSON(pairCollection)
         XCTAssertEqual(json, expected)

--- a/Tests/FreddyTests/JSONTypeTests.swift
+++ b/Tests/FreddyTests/JSONTypeTests.swift
@@ -34,15 +34,9 @@ class JSONTypeTests: XCTestCase {
 
     func testCastInitializeAnyDictionary() {
         let dictionary = ["foo": 1, "bar": 2, "baz": 3]
-        #if swift(>=4.0)
-        let pairCollection = dictionary.lazy.map { arg in
-            (arg.key, JSON(arg.value * 2))
+        let pairCollection = dictionary.lazy.map { pair in
+            (pair.key, JSON(pair.value * 2))
         }
-        #else
-        let pairCollection = dictionary.lazy.map { (key, value) in
-            (key, JSON(value * 2))
-        }
-        #endif
         let expected: JSON = .dictionary(["foo": 2, "bar": 4, "baz": 6])
         let json = JSON(pairCollection)
         XCTAssertEqual(json, expected)


### PR DESCRIPTION
This applies minimal changes to allow Freddy to compile under Swift 4. It polyfills the Swift 4 overflowing `Int` add/multiply API for Swift 3.

It also tweaks some code to treat `Dictionary.map`'s tuple argument as a single argument under both Swift 3 and 4, since Swift 4 won't automatically "splat" it into two separate arguments in the transform block.