### PR TITLE
Use Int overflow polyfill for Swift 3.2+, not just Swift 4.0+

### DIFF
--- a/Sources/IntExtensions.swift
+++ b/Sources/IntExtensions.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-#if swift(>=4.0)
+#if swift(>=3.2)
 #else
 
 public enum ArithmeticOverflow {


### PR DESCRIPTION
The extension on `Int` has a Swift version check which assumes version `4.0`, however, we did not anticipate version `3.2`. To compile Freddy without upgrading to `4.0` and keeping with Swift 3.2 we need to make sure version check on the `Int` takes into account `3.2`. 

This project builds successfully with Xcode 9 and Xcode 8.3.