### PR TITLE
Add Decimal support

### DIFF
--- a/Sources/JSON.swift
+++ b/Sources/JSON.swift
@@ -12,6 +12,8 @@ public enum JSON {
     case array([JSON])
     /// A case for denoting a dictionary with an associated value of `[Swift.String: JSON]`
     case dictionary([String: JSON])
+    /// A case for denoting a decimal with an associated value of `Swift.Decimal`.
+    case decimal(Decimal)
     /// A case for denoting a double with an associated value of `Swift.Double`.
     case double(Double)
     /// A case for denoting an integer with an associated value of `Swift.Int`.
@@ -50,6 +52,18 @@ extension JSON {
 
 // MARK: - Test Equality
 
+public extension Decimal {
+    var doubleValue: Double {
+        return NSDecimalNumber(decimal:self).doubleValue
+    }
+    var intValue: Int {
+        return NSDecimalNumber(decimal:self).intValue
+    }
+    var stringValue: String {
+        return NSDecimalNumber(decimal:self).stringValue
+    }
+}
+
 /// Return `true` if `lhs` is equal to `rhs`.
 public func ==(lhs: JSON, rhs: JSON) -> Bool {
     switch (lhs, rhs) {
@@ -59,6 +73,16 @@ public func ==(lhs: JSON, rhs: JSON) -> Bool {
         return dictL == dictR
     case (.string(let strL), .string(let strR)):
         return strL == strR
+    case (.decimal(let decL), .decimal(let decR)):
+        return decL == decR
+    case (.decimal(let decL), .double(let dubR)):
+        return decL.doubleValue == dubR
+    case (.double(let dubL), .decimal(let decR)):
+        return dubL == decR.doubleValue
+    case (.decimal(let decL), .int(let intR)):
+        return decL.doubleValue == Double(intR)
+    case (.int(let intL), .decimal(let decR)):
+        return Double(intL) == decR.doubleValue
     case (.double(let dubL), .double(let dubR)):
         return dubL == dubR
     case (.double(let dubL), .int(let intR)):
@@ -88,6 +112,7 @@ extension JSON: CustomStringConvertible {
         case .array(let arr):       return String(describing: arr)
         case .dictionary(let dict): return String(describing: dict)
         case .string(let string):   return string
+            case .decimal(let decimal): return String(describing: decimal)
         case .double(let double):   return String(describing: double)
         case .int(let int):         return String(describing: int)
         case .bool(let bool):       return String(describing: bool)

--- a/Sources/JSONDecodable.swift
+++ b/Sources/JSONDecodable.swift
@@ -19,6 +19,28 @@ public protocol JSONDecodable {
     
 }
 
+extension Decimal: JSONDecodable {
+    
+    /// An initializer to create an instance of `Decimal` from a `JSON` value.
+    /// - parameter json: An instance of `JSON`.
+    /// - throws: The initializer will throw an instance of `JSON.Error` if
+    ///           an instance of `Decimal` cannot be created from the `JSON` value that was
+    ///           passed to this initializer.
+    public init(json: JSON) throws {
+        switch json {
+        case let .decimal(decimal):
+            self = decimal
+        case let .double(double):
+            self = Decimal(double)
+        case let .int(int):
+            self = Decimal(int)
+        default:
+            throw JSON.Error.valueNotConvertible(value: json, to: Decimal.self)
+        }
+    }
+    
+}
+
 extension Double: JSONDecodable {
     
     /// An initializer to create an instance of `Double` from a `JSON` value.
@@ -28,6 +50,8 @@ extension Double: JSONDecodable {
     ///           passed to this initializer.
     public init(json: JSON) throws {
         switch json {
+        case let .decimal(decimal):
+            self = decimal.doubleValue
         case let .double(double):
             self = double
         case let .int(int):
@@ -48,6 +72,8 @@ extension Int: JSONDecodable {
     ///           passed to this initializer.
     public init(json: JSON) throws {
         switch json {
+        case let .decimal(decimal):
+            self = decimal.intValue
         case let .double(double) where double <= Double(Int.max):
             self = Int(double)
         case let .int(int):
@@ -76,6 +102,8 @@ extension String: JSONDecodable {
             self = String(bool)
         case let .double(double):
             self = String(double)
+        case let .decimal(decimal):
+            self = decimal.stringValue
         default:
             throw JSON.Error.valueNotConvertible(value: json, to: String.self)
         }

--- a/Sources/JSONEncodable.swift
+++ b/Sources/JSONEncodable.swift
@@ -50,6 +50,14 @@ extension Int: JSONEncodable {
     }
 }
 
+extension Decimal: JSONEncodable {
+    /// Converts an instance of a conforming type to `JSON`.
+    /// - returns: An instance of `JSON` where the enum case is `.decimal`.
+    public func toJSON() -> JSON {
+        return .decimal(self)
+    }
+}
+
 extension Double: JSONEncodable {
     /// Converts an instance of a conforming type to `JSON`.
     /// - returns: An instance of `JSON` where the enum case is `.double`.

--- a/Sources/JSONLiteralConvertible.swift
+++ b/Sources/JSONLiteralConvertible.swift
@@ -61,6 +61,16 @@ extension JSON: ExpressibleByFloatLiteral {
     public init(floatLiteral value: Swift.Double) {
         self.init(value)
     }
+    
+    /// Create an instance initialized to `Decimal` `value`.
+    public init(_ value: Decimal) {
+        self = .decimal(value)
+    }
+    
+    /// Create a literal instance initialized to `value`.
+    public init(floatLiteral value: Decimal) {
+        self.init(value)
+    }
 
 }
 

--- a/Sources/JSONParser.swift
+++ b/Sources/JSONParser.swift
@@ -468,7 +468,7 @@ public struct JSONParser {
 
             case .decimal, .exponent:
                 return try detectingFloatingPointErrors(start: parser.start) {
-                    try decodeFloatingPointValue(parser, sign: sign, value: Double(value))
+                    try decodeFloatingPointValue(parser, sign: sign, value: Decimal(value))
                 }
 
             case .postDecimalDigits, .exponentSign, .exponentDigits:
@@ -487,12 +487,12 @@ public struct JSONParser {
         return .int(signedValue)
     }
 
-    private mutating func decodeFloatingPointValue(_ parser: NumberParser, sign: Sign, value: Double) throws -> JSON {
+    private mutating func decodeFloatingPointValue(_ parser: NumberParser, sign: Sign, value: Decimal) throws -> JSON {
         var parser = parser
         var value = value
         var exponentSign = Sign.positive
-        var exponent = Double(0)
-        var position = 0.1
+        var exponent = Decimal(0)
+        var position: Decimal = 0.1
 
         // This would be more natural as `while true { ... }` with a meaningful .Done case,
         // but that causes compile time explosion in Swift 2.2. :-|
@@ -506,8 +506,8 @@ public struct JSONParser {
 
             case .postDecimalDigits:
                 parser.parsePostDecimalDigits { c in
-                    value += position * Double(c - Literal.zero)
-                    position /= 10
+                    value += position * Decimal(c - Literal.zero)
+                    position = position / 10
                 }
 
             case .exponent:
@@ -518,7 +518,7 @@ public struct JSONParser {
 
             case .exponentDigits:
                 parser.parseExponentDigits { c in
-                    exponent = exponent * 10 + Double(c - Literal.zero)
+                    exponent = exponent * 10 + Decimal(c - Literal.zero)
                 }
 
             case .done:
@@ -527,7 +527,7 @@ public struct JSONParser {
         }
 
         loc = parser.loc
-        return .double(Double(sign.rawValue) * value * pow(10, Double(exponentSign.rawValue) * exponent))
+        return .decimal(Decimal(Double(sign.rawValue) * value.doubleValue * pow(10, Double(exponentSign.rawValue) * exponent.doubleValue)))
     }
 
 

--- a/Sources/JSONParsing.swift
+++ b/Sources/JSONParsing.swift
@@ -86,7 +86,7 @@ extension JSONSerialization: JSONParserType {
                 #endif
 
             case .float32Type, .float64Type, .floatType, .doubleType, .cgFloatType:
-                return .double(n.doubleValue)
+                return .decimal(n.decimalValue)
             }
 
         case let arr as [Any]:

--- a/Sources/JSONSerializing.swift
+++ b/Sources/JSONSerializing.swift
@@ -40,6 +40,8 @@ extension JSON {
             return cocoaDictionary
         case .string(let str):
             return str
+        case .decimal(let dec):
+            return NSDecimalNumber(decimal: dec)
         case .double(let num):
             return NSNumber(value: num)
         case .int(let int):

--- a/Sources/JSONSubscripting.swift
+++ b/Sources/JSONSubscripting.swift
@@ -145,6 +145,15 @@ extension JSON {
     public func decode<Decoded: JSONDecodable>(at path: JSONPathType..., type: Decoded.Type = Decoded.self) throws -> Decoded {
         return try Decoded(json: value(at: path))
     }
+    
+    /// Retrieves a `Decimal` from a path into JSON.
+    /// - parameter path: 0 or more `String` or `Int` that subscript the `JSON`
+    /// - returns: A floating-point `Decimal`
+    /// - throws: One of the `JSON.Error` cases thrown by `decode(at:type:)`.
+    /// - seealso: `JSON.decode(at:type:)`
+    public func getDecimal(at path: JSONPathType...) throws -> Decimal {
+        return try Decimal(json: value(at: path))
+    }
 
     /// Retrieves a `Double` from a path into JSON.
     /// - parameter path: 0 or more `String` or `Int` that subscript the `JSON`
@@ -300,6 +309,23 @@ extension JSON {
     ///   * Any error that arises from decoding the value.
     public func decode<Decoded: JSONDecodable>(at path: JSONPathType..., alongPath options: SubscriptingOptions, type: Decoded.Type = Decoded.self) throws -> Decoded? {
         return try mapOptional(at: path, alongPath: options, transform: JSON.getDecoded)
+    }
+    
+    /// Optionally retrieves a `Decimal` from a path into JSON.
+    /// - parameter path: 0 or more `String` or `Int` that subscript the `JSON`.
+    /// - parameter alongPath: Options that control what should be done with values that are `null` or keys that are missing.
+    /// - returns: A `Decimal` if a value could be found, otherwise `nil`.
+    /// - throws: One of the following errors contained in `JSON.Error`:
+    ///   * `KeyNotFound`: A key `path` does not exist inside a descendant
+    ///     `JSON` dictionary.
+    ///   * `IndexOutOfBounds`: An index `path` is outside the bounds of a
+    ///     descendant `JSON` array.
+    ///   * `UnexpectedSubscript`: A `path` item cannot be used with the
+    ///     corresponding `JSON` value.
+    ///   * `TypeNotConvertible`: The target value's type inside of the `JSON`
+    ///     instance does not match the decoded value.
+    public func getDecimal(at path: JSONPathType..., alongPath options: SubscriptingOptions) throws -> Decimal? {
+        return try mapOptional(at: path, alongPath: options, transform: Decimal.init)
     }
 
     /// Optionally retrieves a `Double` from a path into JSON.
@@ -474,6 +500,15 @@ extension JSON {
     ///     the `JSON` instance does not match `Decoded`.
     public func decode<Decoded: JSONDecodable>(at path: JSONPathType..., or fallback: @autoclosure() -> Decoded) throws -> Decoded {
         return try mapOptional(at: path, fallback: fallback, transform: Decoded.init)
+    }
+    
+    /// Retrieves a `Decimal` from a path into JSON or a fallback if not found.
+    /// - parameter path: 0 or more `String` or `Int` that subscript the `JSON`
+    /// - parameter fallback: `Decimal` to use when one is missing at the subscript.
+    /// - returns: A floating-point `Decimal`
+    /// - throws: One of the `JSON.Error` cases thrown by calling `mapOptional(at:fallback:transform:)`.
+    public func getDecimal(at path: JSONPathType..., or fallback: @autoclosure() -> Decimal) throws -> Decimal {
+        return try mapOptional(at: path, fallback: fallback, transform: Decimal.init)
     }
     
     /// Retrieves a `Double` from a path into JSON or a fallback if not found.


### PR DESCRIPTION
This PR adds `Decimal` support to Freddy.

We needed this to avoid floating-point rounding (ex: where 99.99 would end up being stored as 99.98999999999999).