### PR TITLE
Fixing missingKeyBecomesNil being recursive

### DIFF
--- a/Sources/JSONSubscripting.swift
+++ b/Sources/JSONSubscripting.swift
@@ -255,14 +255,16 @@ extension JSON {
         var json: JSON?
         do {
             json = try value(at: path, detectingNull: detectNull)
-            return try json.map(transform)
         } catch Error.indexOutOfBounds where detectNotFound {
             return nil
         } catch Error.keyNotFound where detectNotFound {
             return nil
-        } catch Error.valueNotConvertible where detectNull && json == .null {
-            return nil
         } catch SubscriptError.subscriptIntoNull where detectNull {
+            return nil
+        }
+        do {
+            return try json.map(transform)
+        } catch Error.valueNotConvertible where detectNull && json == .null {
             return nil
         }
     }

--- a/Tests/FreddyTests/JSONSubscriptingTests.swift
+++ b/Tests/FreddyTests/JSONSubscriptingTests.swift
@@ -421,6 +421,33 @@ class JSONSubscriptingTests: XCTestCase {
         XCTAssertNil(string)
     }
     
+    func testMissingKeyBecomesNilIsntRecursive() {
+        
+        struct A: JSONDecodable {
+            let b: B?
+            
+            init(json: JSON) throws {
+                b = try json.decode(at: "b", alongPath: [.missingKeyBecomesNil])
+            }
+            
+        }
+        
+        struct B: JSONDecodable {
+            let string: String
+            
+            init(json: JSON) throws {
+                string = try json.decode(at: "string")
+            }
+        }
+        
+        
+        let json: JSON = [
+            "b": [:]
+        ]
+        
+        XCTAssertThrowsError(try json.decode() as A)
+    }
+    
 }
 
 private struct Resident {


### PR DESCRIPTION
Here's a fix for the `.missingKeyBecomesNil` Option catching errors from decode calls below.

For instance:

```Swift
     struct A: JSONDecodable {
            let b: B?
            
            init(json: JSON) throws {
                b = try json.decode(at: "b", alongPath: [.missingKeyBecomesNil])
            }
            
        }
        
        struct B: JSONDecodable {
            let string: String
            
            init(json: JSON) throws {
                string = try json.decode(at: "string")
            }
        }
```

If I were to call decode with the following invalid json: 

```json
{
    "b": {
    
    }
}
```

The previous implementation wouldn't throw an error but return `A(b: nil)`