### PR TITLE
fix self reference warning

### DIFF
--- a/Sources/JSONDecodable.swift
+++ b/Sources/JSONDecodable.swift
@@ -134,7 +134,7 @@ internal extension JSON {
     static func getArray(from json: JSON) throws -> [JSON] {
         // Ideally should be expressed as a conditional protocol implementation on Swift.Array.
         guard case let .array(array) = json else {
-            throw Error.valueNotConvertible(value: json, to: Swift.Array<JSON>)
+            throw Error.valueNotConvertible(value: json, to: Swift.Array<JSON>.self)
         }
         return array
     }
@@ -147,7 +147,7 @@ internal extension JSON {
     static func getDictionary(from json: JSON) throws -> [String: JSON] {
         // Ideally should be expressed as a conditional protocol implementation on Swift.Dictionary.
         guard case let .dictionary(dictionary) = json else {
-            throw Error.valueNotConvertible(value: json, to: Swift.Dictionary<String, JSON>)
+            throw Error.valueNotConvertible(value: json, to: Swift.Dictionary<String, JSON>.self)
         }
         return dictionary
     }
@@ -174,7 +174,7 @@ internal extension JSON {
     /// - seealso: `JSON.decode(_:type:)`
     static func decodedDictionary<Decoded: JSONDecodable>(from json: JSON) throws -> [Swift.String: Decoded] {
         guard case let .dictionary(dictionary) = json else {
-            throw Error.valueNotConvertible(value: json, to: Swift.Dictionary<String, Decoded>)
+            throw Error.valueNotConvertible(value: json, to: Swift.Dictionary<String, Decoded>.self)
         }
         var decodedDictionary = Swift.Dictionary<String, Decoded>(minimumCapacity: dictionary.count)
         for (key, value) in dictionary {

--- a/Tests/FreddyTests/JSONDecodableTests.swift
+++ b/Tests/FreddyTests/JSONDecodableTests.swift
@@ -228,7 +228,7 @@ class JSONDecodableTests: XCTestCase {
         let oneTwoThreeJSON: JSON = [1,2,3]
         
         do {
-            let decodedOneTwoThree = try oneTwoThreeJSON.decodedArray(type: Swift.Int)
+            let decodedOneTwoThree = try oneTwoThreeJSON.decodedArray(type: Swift.Int.self)
             XCTAssertEqual(decodedOneTwoThree, [1,2,3], "`decodedOneTwoThree` should be equal to `[1,2,3]`.")
         } catch {
             XCTFail("`decodedOneTwoThree` should be equal to `[1,2,3]`.")
@@ -239,7 +239,7 @@ class JSONDecodableTests: XCTestCase {
         let oneTwoThreeJSON: JSON = ["one": 1, "two": 2, "three": 3]
         
         do {
-            let decodedOneTwoThree = try oneTwoThreeJSON.decodedDictionary(type: Swift.Int)
+            let decodedOneTwoThree = try oneTwoThreeJSON.decodedDictionary(type: Swift.Int.self)
             XCTAssertEqual(decodedOneTwoThree, ["one": 1, "two": 2, "three": 3], "`decodedOneTwoThree` should be equal to `[\"one\": 1, \"two\": 2, \"three\": 3]`.")
         } catch {
             XCTFail("`decodedOneTwoThree` should be equal to `[\"one\": 1, \"two\": 2, \"three\": 3]`.")

--- a/Tests/FreddyTests/JSONSubscriptingTests.swift
+++ b/Tests/FreddyTests/JSONSubscriptingTests.swift
@@ -306,7 +306,7 @@ class JSONSubscriptingTests: XCTestCase {
         do {
             _ = try residentJSON.decode(at: "residents", 1, "name", "initial", type: Resident.self)
         } catch JSON.Error.unexpectedSubscript(let type) {
-            XCTAssert(type == Swift.String, "The dictionary at index 1 should not be subscriptable by: \(type).")
+            XCTAssert(type == Swift.String.self, "The dictionary at index 1 should not be subscriptable by: \(type).")
         } catch {
             XCTFail("This should not be: \(error).")
         }
@@ -392,7 +392,7 @@ class JSONSubscriptingTests: XCTestCase {
         do {
             _ = try json.getInt(at: "people", 0, "name")
         } catch let JSON.Error.valueNotConvertible(value, to) {
-            XCTAssert(to == Swift.Int, "The error should be due the value not being an `Int` case, but was \(to).")
+            XCTAssert(to == Swift.Int.self, "The error should be due the value not being an `Int` case, but was \(to).")
             XCTAssert(value == "Matt Mathias", "The error should be due the value being the String 'Matt Mathias', but was \(value).")
         } catch {
             XCTFail("The error should be due to `name` not being convertible to `int`, but was: \(error).")
@@ -403,7 +403,7 @@ class JSONSubscriptingTests: XCTestCase {
         do {
             _ = try json.getString(at: "people", "name")
         } catch JSON.Error.unexpectedSubscript(let type) {
-            XCTAssert(type == Swift.String, "The error should be due the value not being subscriptable with string `String` case, but was \(type).")
+            XCTAssert(type == Swift.String.self, "The error should be due the value not being subscriptable with string `String` case, but was \(type).")
         } catch {
             XCTFail("The error should be due to the `people` `Array` not being subscriptable with `String`s, but was: \(error).")
         }


### PR DESCRIPTION
# Adds Missing Self References
This PR adds missing `self` references in response to warnings in recent versions of Xcode. The specific warning addressed is
`Missing '.self' for reference to meta type of type ...`

-jwd