### PR TITLE
Fix build errors with Xcode 9

### DIFF
--- a/Freddy.xcodeproj/project.pbxproj
+++ b/Freddy.xcodeproj/project.pbxproj
@@ -474,7 +474,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0720;
-				LastUpgradeCheck = 0800;
+				LastUpgradeCheck = 0900;
 				ORGANIZATIONNAME = "Big Nerd Ranch";
 				TargetAttributes = {
 					DB6ADF1E1C23610B00D77BF1 = {
@@ -734,6 +734,12 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = DB6ADF801C23617500D77BF1 /* Debug.xcconfig */;
 			buildSettings = {
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				ENABLE_TESTABILITY = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -744,6 +750,12 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = DB6ADF821C23617500D77BF1 /* Release.xcconfig */;
 			buildSettings = {
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				SDKROOT = iphoneos;
 			};
 			name = Release;

--- a/Freddy.xcodeproj/xcshareddata/xcschemes/Freddy.xcscheme
+++ b/Freddy.xcodeproj/xcshareddata/xcschemes/Freddy.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0900"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -40,6 +40,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES"
       codeCoverageEnabled = "YES">
       <Testables>
@@ -70,6 +71,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Freddy.xcodeproj/xcshareddata/xcschemes/MobileFreddy.xcscheme
+++ b/Freddy.xcodeproj/xcshareddata/xcschemes/MobileFreddy.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0900"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -40,6 +40,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES"
       codeCoverageEnabled = "YES">
       <Testables>
@@ -70,6 +71,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Freddy.xcodeproj/xcshareddata/xcschemes/NanoFreddy.xcscheme
+++ b/Freddy.xcodeproj/xcshareddata/xcschemes/NanoFreddy.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0900"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -36,6 +37,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Freddy.xcodeproj/xcshareddata/xcschemes/TVFreddy.xcscheme
+++ b/Freddy.xcodeproj/xcshareddata/xcschemes/TVFreddy.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0900"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -40,6 +40,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES"
       codeCoverageEnabled = "YES">
       <Testables>
@@ -70,6 +71,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Sources/JSONDecodable.swift
+++ b/Sources/JSONDecodable.swift
@@ -134,7 +134,7 @@ internal extension JSON {
     static func getArray(from json: JSON) throws -> [JSON] {
         // Ideally should be expressed as a conditional protocol implementation on Swift.Array.
         guard case let .array(array) = json else {
-            throw Error.valueNotConvertible(value: json, to: Swift.Array<JSON>)
+            throw Error.valueNotConvertible(value: json, to: Swift.Array<JSON>.self)
         }
         return array
     }
@@ -147,7 +147,7 @@ internal extension JSON {
     static func getDictionary(from json: JSON) throws -> [String: JSON] {
         // Ideally should be expressed as a conditional protocol implementation on Swift.Dictionary.
         guard case let .dictionary(dictionary) = json else {
-            throw Error.valueNotConvertible(value: json, to: Swift.Dictionary<String, JSON>)
+            throw Error.valueNotConvertible(value: json, to: Swift.Dictionary<String, JSON>.self)
         }
         return dictionary
     }
@@ -174,7 +174,7 @@ internal extension JSON {
     /// - seealso: `JSON.decode(_:type:)`
     static func decodedDictionary<Decoded: JSONDecodable>(from json: JSON) throws -> [Swift.String: Decoded] {
         guard case let .dictionary(dictionary) = json else {
-            throw Error.valueNotConvertible(value: json, to: Swift.Dictionary<String, Decoded>)
+            throw Error.valueNotConvertible(value: json, to: Swift.Dictionary<String, Decoded>.self)
         }
         var decodedDictionary = Swift.Dictionary<String, Decoded>(minimumCapacity: dictionary.count)
         for (key, value) in dictionary {

--- a/Sources/JSONParser.swift
+++ b/Sources/JSONParser.swift
@@ -455,14 +455,14 @@ public struct JSONParser {
                 parser.parseLeadingZero()
 
             case .preDecimalDigits:
-                var mutableParser = parser
-                try mutableParser.parsePreDecimalDigits { c in
+                let start = parser.start
+                try parser.parsePreDecimalDigits { c in
                     guard case let (exponent, false) = 10.multipliedReportingOverflow(by: value) else {
-                        throw InternalError.numberOverflow(offset: parser.start)
+                        throw InternalError.numberOverflow(offset: start)
                     }
                     
                     guard case let (newValue, false) = exponent.addingReportingOverflow(Int(c - Literal.zero)) else {
-                        throw InternalError.numberOverflow(offset: parser.start)
+                        throw InternalError.numberOverflow(offset: start)
                     }
                     
                     value = newValue

--- a/Sources/JSONParser.swift
+++ b/Sources/JSONParser.swift
@@ -455,12 +455,13 @@ public struct JSONParser {
                 parser.parseLeadingZero()
 
             case .preDecimalDigits:
-                try parser.parsePreDecimalDigits { c in
-                    guard case let (exponent, .none) = 10.multipliedReportingOverflow(by: value) else {
+                var mutableParser = parser
+                try mutableParser.parsePreDecimalDigits { c in
+                    guard case let (exponent, false) = 10.multipliedReportingOverflow(by: value) else {
                         throw InternalError.numberOverflow(offset: parser.start)
                     }
                     
-                    guard case let (newValue, .none) = exponent.addingReportingOverflow(Int(c - Literal.zero)) else {
+                    guard case let (newValue, false) = exponent.addingReportingOverflow(Int(c - Literal.zero)) else {
                         throw InternalError.numberOverflow(offset: parser.start)
                     }
                     
@@ -480,7 +481,7 @@ public struct JSONParser {
             }
         }
 
-        guard case let (signedValue, .none) = sign.rawValue.multipliedReportingOverflow(by: value) else {
+        guard case let (signedValue, false) = sign.rawValue.multipliedReportingOverflow(by: value) else {
             throw InternalError.numberOverflow(offset: parser.start)
         }
 


### PR DESCRIPTION
2 issues were present:

- a few type specifiers were missing the `.self` suffix. This was not required in previous versions of Swift, but now fails to compile. These have been added.

- `func multipliedReportingOverflow` now returns `Bool` instead of an optional as the 2nd part of its tuple. Usages were corrected to pattern match on `false` instead of `.none`