### PR TITLE
Replace assertions with errors

### DIFF
--- a/Freddy.xcodeproj/project.pbxproj
+++ b/Freddy.xcodeproj/project.pbxproj
@@ -474,7 +474,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0720;
-				LastUpgradeCheck = 0800;
+				LastUpgradeCheck = 0900;
 				ORGANIZATIONNAME = "Big Nerd Ranch";
 				TargetAttributes = {
 					DB6ADF1E1C23610B00D77BF1 = {
@@ -734,6 +734,12 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = DB6ADF801C23617500D77BF1 /* Debug.xcconfig */;
 			buildSettings = {
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				ENABLE_TESTABILITY = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -744,6 +750,12 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = DB6ADF821C23617500D77BF1 /* Release.xcconfig */;
 			buildSettings = {
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				SDKROOT = iphoneos;
 			};
 			name = Release;

--- a/Freddy.xcodeproj/project.pbxproj
+++ b/Freddy.xcodeproj/project.pbxproj
@@ -479,28 +479,31 @@
 				TargetAttributes = {
 					DB6ADF1E1C23610B00D77BF1 = {
 						CreatedOnToolsVersion = 7.2;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0900;
 					};
 					DB6ADF281C23610B00D77BF1 = {
 						CreatedOnToolsVersion = 7.2;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0900;
 					};
 					DB6ADF3D1C23612000D77BF1 = {
 						CreatedOnToolsVersion = 7.2;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0900;
 					};
 					DB6ADF461C23612000D77BF1 = {
 						CreatedOnToolsVersion = 7.2;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0900;
 					};
 					DB6ADF591C23612900D77BF1 = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0900;
 					};
 					DB6ADF621C23612A00D77BF1 = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0900;
 					};
 					DB6ADF751C23613200D77BF1 = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0900;
 					};
 				};
 			};
@@ -765,6 +768,8 @@
 			baseConfigurationReference = DB6ADF811C23617500D77BF1 /* Framework.xcconfig */;
 			buildSettings = {
 				SDKROOT = iphoneos;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -774,6 +779,8 @@
 			baseConfigurationReference = DB6ADF811C23617500D77BF1 /* Framework.xcconfig */;
 			buildSettings = {
 				SDKROOT = iphoneos;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -784,6 +791,8 @@
 			buildSettings = {
 				INFOPLIST_FILE = Tests/FreddyTests/Info.plist;
 				SDKROOT = iphoneos;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -793,6 +802,8 @@
 			buildSettings = {
 				INFOPLIST_FILE = Tests/FreddyTests/Info.plist;
 				SDKROOT = iphoneos;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};
@@ -801,7 +812,8 @@
 			baseConfigurationReference = DB6ADF811C23617500D77BF1 /* Framework.xcconfig */;
 			buildSettings = {
 				SDKROOT = macosx;
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -810,7 +822,8 @@
 			baseConfigurationReference = DB6ADF811C23617500D77BF1 /* Framework.xcconfig */;
 			buildSettings = {
 				SDKROOT = macosx;
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};
@@ -820,7 +833,8 @@
 			buildSettings = {
 				INFOPLIST_FILE = Tests/FreddyTests/Info.plist;
 				SDKROOT = macosx;
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -830,7 +844,8 @@
 			buildSettings = {
 				INFOPLIST_FILE = Tests/FreddyTests/Info.plist;
 				SDKROOT = macosx;
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};
@@ -839,6 +854,8 @@
 			baseConfigurationReference = DB6ADF811C23617500D77BF1 /* Framework.xcconfig */;
 			buildSettings = {
 				SDKROOT = appletvos;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = 3;
 			};
 			name = Debug;
@@ -848,6 +865,8 @@
 			baseConfigurationReference = DB6ADF811C23617500D77BF1 /* Framework.xcconfig */;
 			buildSettings = {
 				SDKROOT = appletvos;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = 3;
 			};
 			name = Release;
@@ -858,6 +877,8 @@
 			buildSettings = {
 				INFOPLIST_FILE = Tests/FreddyTests/Info.plist;
 				SDKROOT = appletvos;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -867,6 +888,8 @@
 			buildSettings = {
 				INFOPLIST_FILE = Tests/FreddyTests/Info.plist;
 				SDKROOT = appletvos;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};
@@ -875,6 +898,8 @@
 			baseConfigurationReference = DB6ADF811C23617500D77BF1 /* Framework.xcconfig */;
 			buildSettings = {
 				SDKROOT = watchos;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = 4;
 			};
 			name = Debug;
@@ -884,6 +909,8 @@
 			baseConfigurationReference = DB6ADF811C23617500D77BF1 /* Framework.xcconfig */;
 			buildSettings = {
 				SDKROOT = watchos;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = 4;
 			};
 			name = Release;

--- a/Freddy.xcodeproj/xcshareddata/xcschemes/Freddy.xcscheme
+++ b/Freddy.xcodeproj/xcshareddata/xcschemes/Freddy.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0900"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -40,6 +40,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES"
       codeCoverageEnabled = "YES">
       <Testables>
@@ -70,6 +71,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Freddy.xcodeproj/xcshareddata/xcschemes/MobileFreddy.xcscheme
+++ b/Freddy.xcodeproj/xcshareddata/xcschemes/MobileFreddy.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0900"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -40,6 +40,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES"
       codeCoverageEnabled = "YES">
       <Testables>
@@ -70,6 +71,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Freddy.xcodeproj/xcshareddata/xcschemes/NanoFreddy.xcscheme
+++ b/Freddy.xcodeproj/xcshareddata/xcschemes/NanoFreddy.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0900"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -36,6 +37,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Freddy.xcodeproj/xcshareddata/xcschemes/TVFreddy.xcscheme
+++ b/Freddy.xcodeproj/xcshareddata/xcschemes/TVFreddy.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0900"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -40,6 +40,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES"
       codeCoverageEnabled = "YES">
       <Testables>
@@ -70,6 +71,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Sources/JSONDecodable.swift
+++ b/Sources/JSONDecodable.swift
@@ -134,7 +134,7 @@ internal extension JSON {
     static func getArray(from json: JSON) throws -> [JSON] {
         // Ideally should be expressed as a conditional protocol implementation on Swift.Array.
         guard case let .array(array) = json else {
-            throw Error.valueNotConvertible(value: json, to: Swift.Array<JSON>)
+            throw Error.valueNotConvertible(value: json, to: Swift.Array<JSON>.self)
         }
         return array
     }
@@ -147,7 +147,7 @@ internal extension JSON {
     static func getDictionary(from json: JSON) throws -> [String: JSON] {
         // Ideally should be expressed as a conditional protocol implementation on Swift.Dictionary.
         guard case let .dictionary(dictionary) = json else {
-            throw Error.valueNotConvertible(value: json, to: Swift.Dictionary<String, JSON>)
+            throw Error.valueNotConvertible(value: json, to: Swift.Dictionary<String, JSON>.self)
         }
         return dictionary
     }
@@ -174,7 +174,7 @@ internal extension JSON {
     /// - seealso: `JSON.decode(_:type:)`
     static func decodedDictionary<Decoded: JSONDecodable>(from json: JSON) throws -> [Swift.String: Decoded] {
         guard case let .dictionary(dictionary) = json else {
-            throw Error.valueNotConvertible(value: json, to: Swift.Dictionary<String, Decoded>)
+            throw Error.valueNotConvertible(value: json, to: Swift.Dictionary<String, Decoded>.self)
         }
         var decodedDictionary = Swift.Dictionary<String, Decoded>(minimumCapacity: dictionary.count)
         for (key, value) in dictionary {

--- a/Sources/JSONParser.swift
+++ b/Sources/JSONParser.swift
@@ -916,5 +916,17 @@ extension JSONParser {
         /// get enough information from Swift here to know which it is. The number
         /// causing the overflow/underflow began at `offset`.
         case numberOverflow(offset: Int)
+
+        /// Attempting to parse a number, but the internal state was incorrect. This
+        /// would indicate an error with the internal parser logic.
+        case invalidInternalState(offset: Int)
+
+        /// Another internal parsing error where we still have some data but we think
+        /// we are done. Some say this is impossible.
+        case missionImpossible(offset: Int)
+
+        /// Attempted to parse a number on a valid that is not a number. This shouldn't
+        /// happen with the internal parser.
+        case parsingNumberOnNotANumber
     }
 }

--- a/Sources/JSONParser.swift
+++ b/Sources/JSONParser.swift
@@ -455,14 +455,14 @@ public struct JSONParser {
                 parser.parseLeadingZero()
 
             case .preDecimalDigits:
-                var mutableParser = parser
-                try mutableParser.parsePreDecimalDigits { c in
+                let start = parser.start
+                try parser.parsePreDecimalDigits { c in
                     guard case let (exponent, false) = 10.multipliedReportingOverflow(by: value) else {
-                        throw InternalError.numberOverflow(offset: parser.start)
+                        throw InternalError.numberOverflow(offset: start)
                     }
                     
                     guard case let (newValue, false) = exponent.addingReportingOverflow(Int(c - Literal.zero)) else {
-                        throw InternalError.numberOverflow(offset: parser.start)
+                        throw InternalError.numberOverflow(offset: start)
                     }
                     
                     value = newValue

--- a/Sources/JSONParser.swift
+++ b/Sources/JSONParser.swift
@@ -455,12 +455,13 @@ public struct JSONParser {
                 parser.parseLeadingZero()
 
             case .preDecimalDigits:
-                try parser.parsePreDecimalDigits { c in
-                    guard case let (exponent, .none) = 10.multipliedReportingOverflow(by: value) else {
+                var mutableParser = parser
+                try mutableParser.parsePreDecimalDigits { c in
+                    guard case let (exponent, false) = 10.multipliedReportingOverflow(by: value) else {
                         throw InternalError.numberOverflow(offset: parser.start)
                     }
                     
-                    guard case let (newValue, .none) = exponent.addingReportingOverflow(Int(c - Literal.zero)) else {
+                    guard case let (newValue, false) = exponent.addingReportingOverflow(Int(c - Literal.zero)) else {
                         throw InternalError.numberOverflow(offset: parser.start)
                     }
                     
@@ -480,7 +481,7 @@ public struct JSONParser {
             }
         }
 
-        guard case let (signedValue, .none) = sign.rawValue.multipliedReportingOverflow(by: value) else {
+        guard case let (signedValue, false) = sign.rawValue.multipliedReportingOverflow(by: value) else {
             throw InternalError.numberOverflow(offset: parser.start)
         }
 

--- a/Sources/JSONParser.swift
+++ b/Sources/JSONParser.swift
@@ -474,10 +474,10 @@ public struct JSONParser {
                 }
 
             case .postDecimalDigits, .exponentSign, .exponentDigits:
-                assertionFailure("Invalid internal state while parsing number")
+                throw InternalError.invalidInternalState(offset: parser.start)
 
             case .done:
-                fatalError("impossible condition")
+                throw InternalError.missionImpossible(offset: parser.start)
             }
         }
 
@@ -501,7 +501,7 @@ public struct JSONParser {
         while parser.state != .done {
             switch parser.state {
             case .leadingMinus, .leadingZero, .preDecimalDigits:
-                assertionFailure("Invalid internal state while parsing number")
+                throw InternalError.invalidInternalState(offset: parser.start)
 
             case .decimal:
                 try parser.parseDecimal()
@@ -524,7 +524,7 @@ public struct JSONParser {
                 }
 
             case .done:
-                fatalError("impossible condition")
+                throw InternalError.missionImpossible(offset: parser.start)
             }
         }
 
@@ -534,14 +534,14 @@ public struct JSONParser {
 
 
     private mutating func decodeNumberAsString(from position: Int) throws -> JSON {
-        var parser: NumberParser = {
+        var parser: NumberParser = try {
             let state: NumberParser.State
             switch input[position] {
             case Literal.MINUS: state = .leadingMinus
             case Literal.zero: state = .leadingZero
             case Literal.one...Literal.nine: state = .preDecimalDigits
             default:
-                fatalError("Internal error: decodeNumber called on not-a-number")
+                 throw InternalError.parsingNumberOnNotANumber
             }
             return NumberParser(loc: position, input: input, state: state)
         }()

--- a/Tests/FreddyTests/JSONDecodableTests.swift
+++ b/Tests/FreddyTests/JSONDecodableTests.swift
@@ -228,7 +228,7 @@ class JSONDecodableTests: XCTestCase {
         let oneTwoThreeJSON: JSON = [1,2,3]
         
         do {
-            let decodedOneTwoThree = try oneTwoThreeJSON.decodedArray(type: Swift.Int)
+            let decodedOneTwoThree = try oneTwoThreeJSON.decodedArray(type: Swift.Int.self)
             XCTAssertEqual(decodedOneTwoThree, [1,2,3], "`decodedOneTwoThree` should be equal to `[1,2,3]`.")
         } catch {
             XCTFail("`decodedOneTwoThree` should be equal to `[1,2,3]`.")
@@ -239,7 +239,7 @@ class JSONDecodableTests: XCTestCase {
         let oneTwoThreeJSON: JSON = ["one": 1, "two": 2, "three": 3]
         
         do {
-            let decodedOneTwoThree = try oneTwoThreeJSON.decodedDictionary(type: Swift.Int)
+            let decodedOneTwoThree = try oneTwoThreeJSON.decodedDictionary(type: Swift.Int.self)
             XCTAssertEqual(decodedOneTwoThree, ["one": 1, "two": 2, "three": 3], "`decodedOneTwoThree` should be equal to `[\"one\": 1, \"two\": 2, \"three\": 3]`.")
         } catch {
             XCTFail("`decodedOneTwoThree` should be equal to `[\"one\": 1, \"two\": 2, \"three\": 3]`.")

--- a/Tests/FreddyTests/JSONParserTests.swift
+++ b/Tests/FreddyTests/JSONParserTests.swift
@@ -200,7 +200,7 @@ class JSONParserTests: XCTestCase {
         ] {
             do {
                 let value = try JSONParser.parse(string).getDouble()
-                XCTAssertEqualWithAccuracy(value, shouldBeDouble, accuracy: DBL_EPSILON)
+                XCTAssertEqual(value, shouldBeDouble, accuracy: Double.ulpOfOne)
             } catch {
                 XCTFail("Unexpected error: \(error)")
             }

--- a/Tests/FreddyTests/JSONSubscriptingTests.swift
+++ b/Tests/FreddyTests/JSONSubscriptingTests.swift
@@ -306,7 +306,7 @@ class JSONSubscriptingTests: XCTestCase {
         do {
             _ = try residentJSON.decode(at: "residents", 1, "name", "initial", type: Resident.self)
         } catch JSON.Error.unexpectedSubscript(let type) {
-            XCTAssert(type == Swift.String, "The dictionary at index 1 should not be subscriptable by: \(type).")
+            XCTAssert(type == Swift.String.self, "The dictionary at index 1 should not be subscriptable by: \(type).")
         } catch {
             XCTFail("This should not be: \(error).")
         }
@@ -392,7 +392,7 @@ class JSONSubscriptingTests: XCTestCase {
         do {
             _ = try json.getInt(at: "people", 0, "name")
         } catch let JSON.Error.valueNotConvertible(value, to) {
-            XCTAssert(to == Swift.Int, "The error should be due the value not being an `Int` case, but was \(to).")
+            XCTAssert(to == Swift.Int.self, "The error should be due the value not being an `Int` case, but was \(to).")
             XCTAssert(value == "Matt Mathias", "The error should be due the value being the String 'Matt Mathias', but was \(value).")
         } catch {
             XCTFail("The error should be due to `name` not being convertible to `int`, but was: \(error).")
@@ -403,7 +403,7 @@ class JSONSubscriptingTests: XCTestCase {
         do {
             _ = try json.getString(at: "people", "name")
         } catch JSON.Error.unexpectedSubscript(let type) {
-            XCTAssert(type == Swift.String, "The error should be due the value not being subscriptable with string `String` case, but was \(type).")
+            XCTAssert(type == Swift.String.self, "The error should be due the value not being subscriptable with string `String` case, but was \(type).")
         } catch {
             XCTFail("The error should be due to the `people` `Array` not being subscriptable with `String`s, but was: \(error).")
         }


### PR DESCRIPTION
Instead of crashing the entire app, this PR turns those cases into thrown errors. Now the calling app can chose what to do in these cases.

Note: These are all internal parsing code errors, so ideally these will not happen unless the parsing code itself is broken. But either way it is more friendly in this case to throw a catchable error rather than crashing.

This will also close #258 with a more robust fix than #259.

Marking with do not merge for now until we create a Xcode 9 / Swift 3.2 release and also depends on #267 .