### PR TITLE
Disable code coverage for release builds

### DIFF
--- a/Freddy.xcodeproj/project.pbxproj
+++ b/Freddy.xcodeproj/project.pbxproj
@@ -773,6 +773,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = DB6ADF811C23617500D77BF1 /* Framework.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_CODE_COVERAGE = NO;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -809,6 +810,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = DB6ADF811C23617500D77BF1 /* Framework.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_CODE_COVERAGE = NO;
 				SDKROOT = macosx;
 				SWIFT_VERSION = 3.0;
 			};
@@ -847,6 +849,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = DB6ADF811C23617500D77BF1 /* Framework.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_CODE_COVERAGE = NO;
 				SDKROOT = appletvos;
 				TARGETED_DEVICE_FAMILY = 3;
 			};
@@ -883,6 +886,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = DB6ADF811C23617500D77BF1 /* Framework.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_CODE_COVERAGE = NO;
 				SDKROOT = watchos;
 				TARGETED_DEVICE_FAMILY = 4;
 			};


### PR DESCRIPTION
This PR Fixes #262 

We have not run into this issue yet, but I see no harm in turning this off for Release builds. There is some chatter online about this:

http://blog.carlossless.io/xcode-9-and-carthage-coverage-data

Seems related to how Carthage builds frameworks, although I suspect something else is going on here. Again I don't see any harm in changing this flag for Release builds as it shouldn't be relevant anyway. Frankly I'm not sure why the default is `Yes` for `Release` anyway.