### PR TITLE
fixes for linux

### DIFF
--- a/Sources/JSONParser.swift
+++ b/Sources/JSONParser.swift
@@ -592,7 +592,7 @@ public struct JSONParser {
     }
 
     private func detectingFloatingPointErrors<T>(start loc: Int, _ f: () throws -> T) throws -> T {
-        let flags = FE_UNDERFLOW | FE_OVERFLOW
+        let flags: Int32 = FE_UNDERFLOW | FE_OVERFLOW
         feclearexcept(flags)
         let value = try f()
         guard fetestexcept(flags) == 0 else {

--- a/Sources/JSONParsing.swift
+++ b/Sources/JSONParsing.swift
@@ -56,14 +56,14 @@ extension JSONSerialization: JSONParserType {
     /// - returns: An instance of `JSON` matching the JSON given to the function.
     public static func makeJSON(with object: Any) -> JSON {
         switch object {
-		case let n as Int:
-			return .int(n)
+        case let n as Int:
+            return .int(n)
 
-		case let n as Double:
-			return .double(n)
-		
-		case let n as Bool:
-			return .bool(n)
+        case let n as Double:
+            return .double(n)
+        
+        case let n as Bool:
+            return .bool(n)
 
         case let arr as [Any]:
             return makeJSONArray(arr)

--- a/Sources/JSONParsing.swift
+++ b/Sources/JSONParsing.swift
@@ -56,38 +56,14 @@ extension JSONSerialization: JSONParserType {
     /// - returns: An instance of `JSON` matching the JSON given to the function.
     public static func makeJSON(with object: Any) -> JSON {
         switch object {
-        case let n as NSNumber:
-            let numberType = CFNumberGetType(n)
-            switch numberType {
-            case .charType:
-                return .bool(n.boolValue)
+		case let n as Int:
+			return .int(n)
 
-            case .shortType, .intType, .longType, .cfIndexType, .nsIntegerType, .sInt8Type, .sInt16Type, .sInt32Type:
-                return .int(n.intValue)
-
-            case .sInt64Type, .longLongType /* overflows 32-bit Int */:
-                #if /* 32-bit arch */ arch(arm) || arch(i386)
-                    // Why double, when the Freddy parser would bump to String?
-                    //
-                    // Returning Double avoids making the type depend on whether you're running
-                    // 32-bit or 64-bit code when using the NSJSONSerialization parser.
-                    // NSJSONSerialization appears to bump numbers larger than Int.max to Double on
-                    // 64-bit platforms but use .SInt64Type on 32-bit platforms.
-                    // If we returned a String here, you'd get a String value on 32-bit,
-                    // but a Double value on 64-bit. Instead, we return Double.
-                    //
-                    // This means that, if you switch parsers,
-                    // you'll have to switch from .double to .string for pulling out
-                    // overflowing values, but if you stick with a single parser,
-                    // you at least won't have architecture-dependent lookups!
-                    return .double(n.doubleValue)
-                #else
-                    return .int(n.intValue)
-                #endif
-
-            case .float32Type, .float64Type, .floatType, .doubleType, .cgFloatType:
-                return .double(n.doubleValue)
-            }
+		case let n as Double:
+			return .double(n)
+		
+		case let n as Bool:
+			return .bool(n)
 
         case let arr as [Any]:
             return makeJSONArray(arr)


### PR DESCRIPTION
Fixes two problems on linux:

* "ambiguous use of FE_UNDERFLOW" fixed with explicit variable type
* Lack of support for CFNumberGetType. Reimplemented using casts